### PR TITLE
Update default executor to use new cimg #1

### DIFF
--- a/src/executors/default.yml
+++ b/src/executors/default.yml
@@ -1,8 +1,8 @@
-description: "The official CircleCI Python Docker image."
+description: "The Prototype CircleCI Python Docker image."
 parameters:
   tag:
-    description: "The `circleci/python` Docker image version tag."
+    description: "The `cimg/python` Docker image version tag."
     type: string
     default: "latest"
 docker:
-  - image: circleci/python:<< parameters.tag >>
+  - image: cimg/python:<< parameters.tag >>


### PR DESCRIPTION
Update default executor to use the prototype cimg/python image, to increase boot time, and reliability.