### PR TITLE
now utilizes new cimg docker image executor

### DIFF
--- a/src/executors/default.yml
+++ b/src/executors/default.yml
@@ -1,8 +1,8 @@
 description: "The official CircleCI Python Docker image."
 parameters:
   tag:
-    description: "The `circleci/python` Docker image version tag."
+    description: "The `cimg/python` Docker image version tag."
     type: string
     default: "latest"
 docker:
-  - image: circleci/python:<< parameters.tag >>
+  - image: cimg/python:<< parameters.tag >>


### PR DESCRIPTION
Updated the executor to use new cimg, solves #1 