### PR TITLE
Add command to uninstall deps from requirements.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Python Orb [![CircleCI Build Status](https://circleci.com/gh/CircleCI-Public/python-orb.svg?style=shield "CircleCI Build Status")](https://circleci.com/gh/CircleCI-Public/python-orb) [![CircleCI Orb Version](https://img.shields.io/badge/endpoint.svg?url=https://badges.circleci.io/orb/circleci/python)][reg-page] [![GitHub License](https://img.shields.io/badge/license-MIT-lightgrey.svg)](https://raw.githubusercontent.com/CircleCI-Public/python-orb/master/LICENSE) [![CircleCI Community](https://img.shields.io/badge/community-CircleCI%20Discuss-343434.svg)](https://discuss.circleci.com/c/ecosystem/orbs)
 
 A python Orb for CircleCI.
-This orb allows you to do common python related tasks on CircleCI such as install python, download modules, caching, etc.
+This orb allows you to do common python related tasks on CircleCI such as install python, manage dependencies, caching, etc.
 
 
 ## Usage

--- a/src/commands/uninstall-deps.yml
+++ b/src/commands/uninstall-deps.yml
@@ -1,0 +1,11 @@
+description: "Uninstall packages from requirements.txt via Pip."
+parameters:
+  requirements_file:
+    description: Path to requirements.txt dependency file.
+    type: string
+    default: requirements.txt
+steps:
+  - run:
+      name: "Uninstall Dependencies"
+      command: |
+        pip uninstall -y -r << parameters.requirements_file >>


### PR DESCRIPTION
### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

This command is added to complement the existing `install-deps.yml` command. Just as somebody might install dependencies from a requirements.txt file, they may also want to _uninstall_ dependencies from a requirements.txt file (perhaps as a build cleanup phase). This does not resolve a specific issue.

### Description

Add command to uninstall python dependencies from a requirements.txt file. Command takes one parameter, path to the reuirements.txt file, and defaults to the current working directory if parameter is not provided. The `-y` flag is included to bypass the confirmation prompt of `pip uninstall`.