### PR TITLE
Don't use latest tag.

### DIFF
--- a/src/executors/default.yml
+++ b/src/executors/default.yml
@@ -3,6 +3,6 @@ parameters:
   tag:
     description: "The `cimg/python` Docker image version tag."
     type: string
-    default: "latest"
+    default: "3.7"
 docker:
   - image: cimg/python:<< parameters.tag >>


### PR DESCRIPTION
1. The `latest` tag shouldn't be used for orbs by default.
2. The `latest` tag for the `cimg/python` image doesn't exist anyway.