### PR TITLE
Cache ~/.local/bin when saving.

### DIFF
--- a/src/commands/save-cache.yml
+++ b/src/commands/save-cache.yml
@@ -8,4 +8,5 @@ steps:
   - save_cache:
       key: << parameters.key >>-{{ checksum "requirements.txt"  }}
       paths:
+        - "/home/circleci/.local/bin/"
         - "/home/circleci/.local/lib/"


### PR DESCRIPTION
If you install a python command with pip, then you get back the library, and no command, and then "pip install --user foo" gives you odd failures where it claims foo is in fact installed! But you can't see ~/.local/bin/foo and you're tearing your hair out.

### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [ x] All new jobs, commands, executors, parameters have descriptions
- [x ] Examples have been added for any significant new features
- [x ] README has been updated, if necessary

### Motivation, issues

If you install a python command with pip, then you get back the library, and no command, and then "pip install --user foo" gives you odd failures where it claims foo is in fact installed! But you can't see ~/.local/bin/foo and you're tearing your hair out.

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

### Description

Cache pip installed binaries as well as libraries to get a more complete record of the cached requirements.

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->
 