### PR TITLE
add option to indicate where the requirements are installed

### DIFF
--- a/src/commands/save-cache.yml
+++ b/src/commands/save-cache.yml
@@ -4,8 +4,12 @@ parameters:
     description: "The cache key to use. The key is immutable."
     type: string
     default: "pip"
+  lib_path:
+    description: "The path where the requirements are saved to."
+    type: string
+    default: "/home/circleci/.local/lib/"
 steps:
   - save_cache:
       key: << parameters.key >>-{{ checksum "requirements.txt"  }}
       paths:
-        - "/home/circleci/.local/lib/"
+        - << parameters.lib_path >>

--- a/src/executors/default.yml
+++ b/src/executors/default.yml
@@ -3,6 +3,6 @@ parameters:
   tag:
     description: "The `cimg/python` Docker image version tag."
     type: string
-    default: "latest"
+    default: "3.8"
 docker:
   - image: cimg/python:<< parameters.tag >>


### PR DESCRIPTION
### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [ ] Examples have been added for any significant new features
- [ ] README has been updated, if necessary

### Motivation, issues

When using `install-deps` command with `local: false` 
OR 
using a different executor image, this path does not exist.

### Description

add option to indicate where the requirements are installed