### PR TITLE
add option to select alternate/additional requirements files

### DIFF
--- a/src/commands/install-deps.yml
+++ b/src/commands/install-deps.yml
@@ -1,15 +1,19 @@
-description: "Install packages from requirements.txt via Pip."
+description: "Install packages from requirements.txt (or any other file) via Pip."
 parameters:
   local:
     description: "Install packages for local user, not globally. Defaults to true."
     type: boolean
     default: true
+  dependency_file:
+    description: "The file to install dependencies from."
+    type: string
+    default: "requirements.txt"
 steps:
   - run:
       name: "Install Dependencies"
       command: |
         if << parameters.local >>; then
-          pip install --user -r requirements.txt
+          pip install --user -r << parameters.dependency_file >>
         else
-          pip install -r requirements.txt
+          pip install -r << parameters.dependency_file >>
         fi

--- a/src/commands/install-deps.yml
+++ b/src/commands/install-deps.yml
@@ -4,7 +4,7 @@ parameters:
     description: "Install packages for local user, not globally. Defaults to true."
     type: boolean
     default: true
-  dependency_file:
+  dependency-file:
     description: "The file to install dependencies from."
     type: string
     default: "requirements.txt"
@@ -13,7 +13,7 @@ steps:
       name: "Install Dependencies"
       command: |
         if << parameters.local >>; then
-          pip install --user -r << parameters.dependency_file >>
+          pip install --user -r << parameters.dependency-file >>
         else
-          pip install -r << parameters.dependency_file >>
+          pip install -r << parameters.dependency-file >>
         fi

--- a/src/commands/load-cache.yml
+++ b/src/commands/load-cache.yml
@@ -4,7 +4,11 @@ parameters:
     description: "The cache key to use. The key is immutable."
     type: string
     default: "pip"
+  dependency-file:
+    description: "The file to install dependencies from."
+    type: string
+    default: "requirements.txt"
 steps:
   - restore_cache:
       keys:
-        - << parameters.key >>-{{ checksum "requirements.txt"  }}
+        - << parameters.key >>-{{ checksum "<<parameters.dependency-file>>" }}

--- a/src/commands/save-cache.yml
+++ b/src/commands/save-cache.yml
@@ -4,12 +4,16 @@ parameters:
     description: "The cache key to use. The key is immutable."
     type: string
     default: "pip"
-  lib_path:
+  dependency-file:
+    description: "The file that the dependencies are installed from."
+    type: string
+    default: "requirements.txt"
+  lib-path:
     description: "The path where the requirements are saved to."
     type: string
     default: "/home/circleci/.local/lib/"
 steps:
   - save_cache:
-      key: << parameters.key >>-{{ checksum "requirements.txt"  }}
+      key: << parameters.key >>-{{ checksum "<<parameters.dependency-file>>"  }}
       paths:
-        - << parameters.lib_path >>
+        - << parameters.lib-path >>

--- a/src/commands/uninstall-deps.yml
+++ b/src/commands/uninstall-deps.yml
@@ -1,6 +1,6 @@
 description: "Uninstall packages from requirements.txt via Pip."
 parameters:
-  requirements_file:
+  requirements-file:
     description: Path to requirements.txt dependency file.
     type: string
     default: requirements.txt
@@ -8,4 +8,4 @@ steps:
   - run:
       name: "Uninstall Dependencies"
       command: |
-        pip uninstall -y -r << parameters.requirements_file >>
+        pip uninstall -y -r << parameters.requirements-file >>


### PR DESCRIPTION
Signed-off-by: Jeff Knurek <j.knurek@travelaudience.com>

### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [ ] Examples have been added for any significant new features
- [ ] README has been updated, if necessary

### Motivation, issues

We have some repos that contain addition requirements files for different setups. Adding this as an optional value make the command more extendable 

### Description

add option to select alternate/additional requirements files
 