### PR TITLE
Support pipenv in the orb [semver:minor]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,34 @@ jobs:
               # pytest would be a dep in requirements.txt
               pytest --version
 
+  install-deps-pipenv-test:
+    executor: python/default
+    steps:
+      - checkout
+      - run:
+          name: Create Pipfile for test
+          command: echo $'[packages]\npytest = "*"' > Pipfile
+      - python/install-deps-pipenv
+      - python/save-venv-cache
+      - python/save-cache:
+          dependency-file: Pipfile.lock
+      - run:
+          command: |
+            cp Pipfile.lock Pipfile.lock.tmp
+            cp Pipfile Pipfile.tmp
+            pipenv run pytest --version
+          name: Ensure pipenv is working and copy lock file for cache testing
+          # replace this with pipenv-orb/pipenv-run when that's available
+      - python/install-deps-pipenv:
+          args: "pytest==4.6.1"
+      - run:
+          command: |
+            cp Pipfile.lock.tmp Pipfile.lock
+            cp Pipfile.tmp Pipfile
+          name: Overwrite the lockfile with the one that should load the cache.
+      - python/load-venv-cache
+      - python/install-deps-pipenv
+
 workflows:
   # This `lint-pack_validate_publish-dev` workflow will run on any commit.
   lint_pack-validate_publish-dev:
@@ -65,6 +93,9 @@ workflows:
     when: << pipeline.parameters.run-integration-tests >>
     jobs:
       - pip-install-test
+      - install-deps-pipenv-test
+      - python/pipenv-install:
+          args: "requests==2.2.0"
       # publish a semver version of the orb. relies on
       # the commit subject containing the text "[semver:patch|minor|major|skip]"
       # as that will determine whether a patch, minor or major
@@ -82,6 +113,8 @@ workflows:
           ssh-fingerprints: 1a:d8:ea:eb:7a:ae:0c:9d:eb:e9:37:0f:66:62:36:9b
           requires:
             - pip-install-test
+            - install-deps-pipenv-test
+            - python/pipenv-install
           filters:
             branches:
               only: master

--- a/src/commands/install-deps-pipenv.yml
+++ b/src/commands/install-deps-pipenv.yml
@@ -1,0 +1,12 @@
+description: >
+  Run pipenv install with provided args.
+parameters:
+  args:
+    description: "Run pipenv install with args"
+    type: string
+    default: ""
+steps:
+  - run:
+      name: "Install Dependencies with pipenv in project directory with Pipfile."
+      command: |
+        pipenv install << parameters.args >>

--- a/src/commands/load-venv-cache.yml
+++ b/src/commands/load-venv-cache.yml
@@ -1,13 +1,13 @@
-description: "Load cached Pip packages."
+description: "Load cached virtualenv"
 parameters:
   key:
     description: "The cache key to use. The key is immutable."
     type: string
-    default: "pip"
+    default: "venv"
   dependency-file:
-    description: "The filename used to cache the pip packages. If you're using pipenv, you'll want to provide Pipfile.lock"
+    description: "The filename use in the key for the venv cache. If you are creating venv's manually use requirements.txt or setup.py"
     type: string
-    default: "requirements.txt"
+    default: "Pipfile.lock"
 steps:
   - restore_cache:
       keys:

--- a/src/commands/save-venv-cache.yml
+++ b/src/commands/save-venv-cache.yml
@@ -1,0 +1,19 @@
+description: "Save virtualenv created by pipenv to the cache"
+parameters:
+  key:
+    description: "The cache key to use. The key is immutable."
+    type: string
+    default: "venv"
+  dependency-file:
+    description: "The file that the dependencies are locked with."
+    type: string
+    default: "Pipfile.lock"
+  lib-path:
+    description: "The path where the virtualenv is created. Currently pipenv's default."
+    type: string
+    default: "/home/circleci/.local/share/virtualenvs"
+steps:
+  - save_cache:
+      key: << parameters.key >>-{{ checksum "<<parameters.dependency-file>>"  }}
+      paths:
+        - << parameters.lib-path >>

--- a/src/examples/work-with-cache-pipenv.yml
+++ b/src/examples/work-with-cache-pipenv.yml
@@ -1,0 +1,24 @@
+description: |
+  An example of working with the Pipenv cache on CircleCI to speed up builds.
+usage:
+  version: 2.1
+  orbs:
+    python: circleci/python@0.3.3
+  workflows:
+    main:
+      jobs:
+        - build
+  jobs:
+    build:
+      executor: python/default
+      steps:
+        - checkout
+        - python/load-venv-cache
+        - python/pipenv-install:
+            # pytest could also be an arg in Pipfile
+            args: "pytest"
+        - python/save-venv-cache
+        - run:
+            name: "Test it"
+            command: |
+              pipenv run pytest --version

--- a/src/examples/work-with-cache.yml
+++ b/src/examples/work-with-cache.yml
@@ -3,7 +3,7 @@ description: |
 usage:
   version: 2.1
   orbs:
-    python: circleci/python@0.1
+    python: circleci/python@0.3.3
   workflows:
     main:
       jobs:

--- a/src/jobs/pipenv-install.yml
+++ b/src/jobs/pipenv-install.yml
@@ -1,0 +1,54 @@
+description: >
+  Setup a pipenv environment with 'pipenv install'
+
+executor:
+  name: default
+  tag: << parameters.version >>
+
+parameters:
+  args:
+    description: "Run pipenv install with args"
+    type: string
+    default: ""
+  venv-cache:
+    description: "Use the lockfile to save the deps. If the lockfile changes we reinstall anyway."
+    type: boolean
+    default: false
+  pypi-cache:
+    description: "Keep the global pipenv and pip package caches for faster rebuilding overall."
+    type: boolean
+    default: true
+  app-dir:
+    type: string
+    default: "~/project"
+    description: Path to the directory containing your package.json file. Not needed if package.json lives in the root.
+  version:
+    type: string
+    default: "3.8"
+    description: |
+      A full version tag must be specified. Example: "3.8"
+      For a full list of releases, see the following: https://hub.docker.com/r/cimg/python
+steps:
+  - attach_workspace:
+      at: << parameters.app-dir >>
+  - checkout
+  - when:
+      condition: << parameters.pypi-cache >>
+      steps:
+        - load-cache:
+            dependency-file: Pipfile.lock
+  - when:
+      condition: << parameters.venv-cache >>
+      steps:
+        - load-venv-cache
+  - install-deps-pipenv:
+      args: << parameters.args >>
+  - when:
+      condition: << parameters.venv-cache >>
+      steps:
+        - save-venv-cache
+  - when:
+      condition: << parameters.pypi-cache >>
+      steps:
+        - save-cache:
+            dependency-file: Pipfile.lock


### PR DESCRIPTION
Add commands for pipenv-install and virtual env caching
Add a job to simplify usage

### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues
With pipenv now in cimg/python this seems like the most logical integration

### Description
Adds commands to install with pipenv, save the cache with a sane default, and restore the cache.
Tests included
 