### PR TITLE
Fix cache key parameter [semver:minor]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,9 +22,11 @@ jobs:
         - run:
               name: "Test pip"
               command: echo "pytest" >> requirements.txt
-        - python/load-cache
+        - python/load-cache:
+              cache-key: v1
         - python/install-deps
-        - python/save-cache
+        - python/save-cache:
+              cache-key: v1
         - run:
             name: "Test"
             command: |

--- a/src/commands/load-cache.yml
+++ b/src/commands/load-cache.yml
@@ -1,6 +1,6 @@
 description: "Load cached Pip packages."
 parameters:
-  key:
+  cache-key:
     description: "The cache key to use. The key is immutable."
     type: string
     default: "pip"
@@ -11,4 +11,4 @@ parameters:
 steps:
   - restore_cache:
       keys:
-        - << parameters.key >>-{{ checksum "<<parameters.dependency-file>>" }}
+        - << parameters.cache-key >>-{{ checksum "<<parameters.dependency-file>>" }}

--- a/src/commands/save-cache.yml
+++ b/src/commands/save-cache.yml
@@ -1,6 +1,6 @@
 description: "Save Pip packages to cache."
 parameters:
-  key:
+  cache-key:
     description: "The cache key to use. The key is immutable."
     type: string
     default: "pip"
@@ -14,7 +14,7 @@ parameters:
     default: "/home/circleci/.local/lib/"
 steps:
   - save_cache:
-      key: << parameters.key >>-{{ checksum "<<parameters.dependency-file>>"  }}
+      key: << parameters.cache-key >>-{{ checksum "<<parameters.dependency-file>>"  }}
       paths:
         - "/home/circleci/.local/bin/"
         - << parameters.lib-path >>


### PR DESCRIPTION
When the schema validation became more restrictive recently,
'key' as a parameter name is not valid at all. Replace it with 'cache-key'.
As the current one doesn't work as is, treating like a patch.

Also, why isn't the template loading?