### PR TITLE
Allow user to specify req.txt name [semver:minor]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,6 +133,11 @@ workflows:
           name: job-test-pip
           pkg-manager: pip
           app-dir: ~/project/sample_pip
+      - python/test:
+          name: job-test-pip-dist
+          pkg-manager: pip-dist
+          app-dir: ~/project/sample_pip
+          pip-dependency-file: setup.py
       # publish a semver version of the orb. relies on
       # the commit subject containing the text "[semver:patch|minor|major|skip]"
       # as that will determine whether a patch, minor or major

--- a/sample_pip/setup.py
+++ b/sample_pip/setup.py
@@ -1,1 +1,4 @@
-import setuptools; setuptools.setup(name="tmp-example",version="0.0.1",author="null",author_email="null",url="null",description="null")
+import setuptools
+setuptools.setup(name="tmp-example",version="0.0.1",author="null",author_email="null",url="null",description="null",install_requires=[
+          'pytest',
+      ])

--- a/src/commands/install-packages.yml
+++ b/src/commands/install-packages.yml
@@ -66,7 +66,9 @@ steps:
                     - -pypi-<<parameters.cache-version>>-<<#parameters.include-branch-in-cache-key>>{{ .Branch }}-<</parameters.include-branch-in-cache-key>>{{ checksum "<< parameters.app-dir >>/poetry.lock" }}
         - when:
             condition:
-              equal: [pip, << parameters.pkg-manager >>]
+              or:
+                - equal: [pip, << parameters.pkg-manager >>]
+                - equal: [pip-dist, << parameters.pkg-manager >>]
             steps:
               - restore_cache:
                   keys:
@@ -169,7 +171,9 @@ steps:
                     - /home/circleci/.cache/pip
         - when:
             condition:
-              equal: [pip, << parameters.pkg-manager >>]
+              or:
+                - equal: [pip, << parameters.pkg-manager >>]
+                - equal: [pip-dist, << parameters.pkg-manager >>]
             steps:
               - save_cache:
                   key: -pypi-<<parameters.cache-version>>-<<#parameters.include-branch-in-cache-key>>{{ .Branch }}-<</parameters.include-branch-in-cache-key>>{{ checksum "<< parameters.app-dir >>/<<parameters.pip-dependency-file>>" }}

--- a/src/commands/install-packages.yml
+++ b/src/commands/install-packages.yml
@@ -8,7 +8,7 @@ parameters:
     type: enum
     enum: [poetry, pipenv, pip, pip-dist]
     default: pipenv
-    description: Which package management tool to use, pipenv, pip or poetry with dependency file. Use, pip-dist, to install a dist package.
+    description: Which package management tool to use, pipenv, pip or poetry with dependency file. Use, pip-dist, to install with project setup.py.
   args:
     type: string
     default: ""

--- a/src/commands/install-packages.yml
+++ b/src/commands/install-packages.yml
@@ -6,9 +6,9 @@ description: >
 parameters:
   pkg-manager:
     type: enum
-    enum: [poetry, pipenv, pip]
+    enum: [poetry, pipenv, pip, pip-dist]
     default: pipenv
-    description: Which package management tool to use, pipenv, pip or poetry.
+    description: Which package management tool to use, pipenv, pip or poetry with dependency file. Use, pip-dist, to install a dist package.
   args:
     type: string
     default: ""
@@ -16,7 +16,9 @@ parameters:
   pip-dependency-file:
     type: string
     default: requirements.txt
-    description: Name of the requirements file that needs to be installed with pip. Prepended with `app-dir`. If using pipenv or poetry, this is ignored.
+    description: |
+      Name of the requirements file that needs to be installed with pip. Prepended with `app-dir`. If using pipenv or poetry, this is ignored.
+      If using `pip-dist`, use this to use the cache checksum against the `setup.py` if desired.
   app-dir:
     type: string
     default: "~/project"
@@ -115,6 +117,15 @@ steps:
             working_directory: <<parameters.app-dir>>
             command: |
               pip install -r <<parameters.pip-dependency-file>> << parameters.args >>
+  - when:
+      condition:
+        equal: [pip-dist, << parameters.pkg-manager >>]
+      steps:
+        - run:
+            name: "Install dependencies with pip using project setup.py"
+            working_directory: <<parameters.app-dir>>
+            command: |
+              pip install -e . << parameters.args >>
   - when:
       condition: << parameters.venv-cache >>
       steps:

--- a/src/commands/install-packages.yml
+++ b/src/commands/install-packages.yml
@@ -12,7 +12,11 @@ parameters:
   args:
     type: string
     default: ""
-    description: Arguments to pass to install command for pipenv and poetry. For pip args are after `-r requirements.txt` as package index options.
+    description: Arguments to pass to install command for pipenv and poetry. For pip, args are after `-r requirements.txt` as package index options.
+  pip-dependency-file:
+    type: string
+    default: requirements.txt
+    description: Name of the requirements file that needs to be installed with pip. Prepended with `app-dir`. If using pipenv or poetry, this is ignored.
   app-dir:
     type: string
     default: "~/project"
@@ -64,7 +68,7 @@ steps:
             steps:
               - restore_cache:
                   keys:
-                    - -pypi-<<parameters.cache-version>>-<<#parameters.include-branch-in-cache-key>>{{ .Branch }}-<</parameters.include-branch-in-cache-key>>{{ checksum "<< parameters.app-dir >>/requirements.txt" }}
+                    - -pypi-<<parameters.cache-version>>-<<#parameters.include-branch-in-cache-key>>{{ .Branch }}-<</parameters.include-branch-in-cache-key>>{{ checksum "<< parameters.app-dir >>/<<parameters.pip-dependency-file>>" }}
                     - -pypi-<<parameters.cache-version>>-<<#parameters.include-branch-in-cache-key>>{{ .Branch }}-<</parameters.include-branch-in-cache-key>>
   - when:
       condition: << parameters.venv-cache >>
@@ -107,10 +111,10 @@ steps:
         equal: [pip, << parameters.pkg-manager >>]
       steps:
         - run:
-            name: "Install dependencies with pip using project requirements.txt"
+            name: "Install dependencies with pip using project <<parameters.pip-dependency-file>>"
             working_directory: <<parameters.app-dir>>
             command: |
-              pip install -r requirements.txt << parameters.args >>
+              pip install -r <<parameters.pip-dependency-file>> << parameters.args >>
   - when:
       condition: << parameters.venv-cache >>
       steps:
@@ -157,7 +161,7 @@ steps:
               equal: [pip, << parameters.pkg-manager >>]
             steps:
               - save_cache:
-                  key: -pypi-<<parameters.cache-version>>-<<#parameters.include-branch-in-cache-key>>{{ .Branch }}-<</parameters.include-branch-in-cache-key>>{{ checksum "<< parameters.app-dir >>/requirements.txt" }}
+                  key: -pypi-<<parameters.cache-version>>-<<#parameters.include-branch-in-cache-key>>{{ .Branch }}-<</parameters.include-branch-in-cache-key>>{{ checksum "<< parameters.app-dir >>/<<parameters.pip-dependency-file>>" }}
                   paths:
                     # depending on how pip is used, store the pypi mirror, pyenv 'global' the site-packages, and user site-pacakges
                     - /home/circleci/.cache/pip

--- a/src/examples/work-with-pip.yml
+++ b/src/examples/work-with-pip.yml
@@ -3,7 +3,7 @@ description: |
 usage:
   version: 2.1
   orbs:
-    python: circleci/python@1.0.0
+    python: circleci/python@1.1.0
   workflows:
     main:
       jobs:
@@ -16,6 +16,10 @@ usage:
         # Install requirements.txt
         - python/install-packages:
             pkg-manager: pip
+        # Install dev-requirements.txt
+        - python/install-packages:
+            pkg-manager: pip
+            pip-dependency-file: dev-requirements.txt
         # install pytest to run tests
         - python/install-packages:
             pkg-manager: pip

--- a/src/jobs/test.yml
+++ b/src/jobs/test.yml
@@ -12,7 +12,7 @@ parameters:
       For a full list of releases, see the following: https://hub.docker.com/r/cimg/python
   pkg-manager:
     type: enum
-    enum: ["pip", "pipenv", "poetry"]
+    enum: ["pip", "pipenv", "poetry", "pip-dist"]
     default: "pip"
     description: Select the package manager to use. Default is pip
   pip-dependency-file:
@@ -85,7 +85,9 @@ steps:
                   command: <<parameters.pkg-manager>> run python -m unittest
         - when:
             condition:
-              equal: [pip, << parameters.pkg-manager >>]
+              or:
+                - equal: [pip, << parameters.pkg-manager >>]
+                - equal: [pip-dist, << parameters.pkg-manager >>]
             steps:
               - run:
                   working_directory: <<parameters.app-dir>>
@@ -115,7 +117,9 @@ steps:
                   command: <<parameters.pkg-manager>> run pytest --junit-xml=test-report/report.xml
         - when:
             condition:
-              equal: [pip, << parameters.pkg-manager >>]
+              or:
+                - equal: [pip, << parameters.pkg-manager >>]
+                - equal: [pip-dist, << parameters.pkg-manager >>]
             steps:
               - run:
                   name: Run tests with global python env

--- a/src/jobs/test.yml
+++ b/src/jobs/test.yml
@@ -15,6 +15,10 @@ parameters:
     enum: ["pip", "pipenv", "poetry"]
     default: "pip"
     description: Select the package manager to use. Default is pip
+  pip-dependency-file:
+    type: string
+    default: requirements.txt
+    description: Name of the requirements file that needs to be installed with pip. Prepended with `app-dir`. If using pipenv or poetry, this is ignored.
   app-dir:
     type: string
     default: "~/project"
@@ -65,6 +69,7 @@ steps:
       venv-cache: <<parameters.venv-cache>>
       include-branch-in-cache-key: <<parameters.include-branch-in-cache-key>>
       args: <<parameters.args>>
+      pip-dependency-file: <<parameters.pip-dependency-file>>
   - when:
       condition:
         equal: ["unittest", << parameters.test-tool >>]


### PR DESCRIPTION
Adds a parameter that allows users to specify a requirements file named something other than requirements.txt. #46

Adds enum to the pkg-manager parameter to support installing the project itself with a valid setup.py. Use the new parameter to use setup.py as the checksum. Will always run `pip install -e .` to ensure the project is installed. #49 
