### PR TITLE
Add python version checksum to cache key [semver:minor]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,7 @@ jobs:
       - python/install-packages:
           pkg-manager: pip
           app-dir: ~/project/sample_pip
+          include-python-in-cache-key: false
       - run:
           name: "Test"
           working_directory: ~/project/sample_pip
@@ -134,10 +135,20 @@ workflows:
           pkg-manager: pip
           app-dir: ~/project/sample_pip
       - python/test:
+          version: 3.8.2
           name: job-test-pip-dist
           pkg-manager: pip-dist
           app-dir: ~/project/sample_pip
-          pip-dependency-file: setup.py
+          include-python-in-cache-key: false
+          post-steps:
+            - run:
+                name: Attempt to set the other python version - this should fail, but if the cache is broken, this will succeed.
+                command: |
+                  ! pyenv local 3.8.6
+            - run:
+                name: If another python version is loaded - its broken - this verifies that it's broken
+                when: on_fail
+                command: python --version
       # publish a semver version of the orb. relies on
       # the commit subject containing the text "[semver:patch|minor|major|skip]"
       # as that will determine whether a patch, minor or major

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,6 @@ jobs:
       - python/install-packages:
           pkg-manager: pip
           app-dir: ~/project/sample_pip
-          include-python-in-cache-key: false
       - run:
           name: "Test"
           working_directory: ~/project/sample_pip

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,7 +139,7 @@ workflows:
           name: job-test-pip-dist
           pkg-manager: pip-dist
           app-dir: ~/project/sample_pip
-          include-python-in-cache-key: false
+          pip-dependency-file: setup.py
           post-steps:
             - run:
                 name: Attempt to set the other python version - this should fail, but if the cache is broken, this will succeed.

--- a/src/commands/install-packages.yml
+++ b/src/commands/install-packages.yml
@@ -45,6 +45,11 @@ parameters:
     default: []
     description: >
       Steps needed between restoring the cache and the install step.
+  include-python-in-cache-key:
+    type: boolean
+    default: true
+    description: >
+      If true, this cache bucket will checksum the pyenv python binary with the cache-key.
 
 steps:
   - when:
@@ -56,14 +61,14 @@ steps:
             steps:
               - restore_cache:
                   keys:
-                    - -pypi-<<parameters.cache-version>>-<<#parameters.include-branch-in-cache-key>>{{ .Branch }}-<</parameters.include-branch-in-cache-key>>{{ checksum "<< parameters.app-dir >>/Pipfile.lock" }}
+                    - -pypi-<<parameters.cache-version>>-<<#parameters.include-branch-in-cache-key>>{{ .Branch }}-<</parameters.include-branch-in-cache-key>>{{ checksum "<< parameters.app-dir >>/Pipfile.lock" }}-<<#parameters.include-python-in-cache-key>>{{ checksum "/home/circleci/.pyenv/version" }}-<</parameters.include-python-in-cache-key>>
         - when:
             condition:
               equal: [poetry, << parameters.pkg-manager >>]
             steps:
               - restore_cache:
                   keys:
-                    - -pypi-<<parameters.cache-version>>-<<#parameters.include-branch-in-cache-key>>{{ .Branch }}-<</parameters.include-branch-in-cache-key>>{{ checksum "<< parameters.app-dir >>/poetry.lock" }}
+                    - -pypi-<<parameters.cache-version>>-<<#parameters.include-branch-in-cache-key>>{{ .Branch }}-<</parameters.include-branch-in-cache-key>>{{ checksum "<< parameters.app-dir >>/poetry.lock" }}-<<#parameters.include-python-in-cache-key>>{{ checksum "/home/circleci/.pyenv/version" }}-<</parameters.include-python-in-cache-key>>
         - when:
             condition:
               or:
@@ -72,8 +77,7 @@ steps:
             steps:
               - restore_cache:
                   keys:
-                    - -pypi-<<parameters.cache-version>>-<<#parameters.include-branch-in-cache-key>>{{ .Branch }}-<</parameters.include-branch-in-cache-key>>{{ checksum "<< parameters.app-dir >>/<<parameters.pip-dependency-file>>" }}
-                    - -pypi-<<parameters.cache-version>>-<<#parameters.include-branch-in-cache-key>>{{ .Branch }}-<</parameters.include-branch-in-cache-key>>
+                    - -pypi-<<parameters.cache-version>>-<<#parameters.include-branch-in-cache-key>>{{ .Branch }}-<</parameters.include-branch-in-cache-key>>{{ checksum "<< parameters.app-dir >>/<<parameters.pip-dependency-file>>" }}-<<#parameters.include-python-in-cache-key>>{{ checksum "/home/circleci/.pyenv/version" }}-<</parameters.include-python-in-cache-key>>
   - when:
       condition: << parameters.venv-cache >>
       steps:
@@ -83,14 +87,14 @@ steps:
             steps:
               - restore_cache:
                   keys:
-                    - -venv-<<parameters.cache-version>>-<<#parameters.include-branch-in-cache-key>>{{ .Branch }}-<</parameters.include-branch-in-cache-key>>{{ checksum "<< parameters.app-dir >>/Pipfile.lock" }}
+                    - -venv-<<parameters.cache-version>>-<<#parameters.include-branch-in-cache-key>>{{ .Branch }}-<</parameters.include-branch-in-cache-key>>{{ checksum "<< parameters.app-dir >>/Pipfile.lock" }}-<<#parameters.include-python-in-cache-key>>{{ checksum "/home/circleci/.pyenv/version" }}-<</parameters.include-python-in-cache-key>>
         - when:
             condition:
               equal: [poetry, << parameters.pkg-manager >>]
             steps:
               - restore_cache:
                   keys:
-                    - -venv-<<parameters.cache-version>>-<<#parameters.include-branch-in-cache-key>>{{ .Branch }}-<</parameters.include-branch-in-cache-key>>{{ checksum "<< parameters.app-dir >>/poetry.lock" }}
+                    - -venv-<<parameters.cache-version>>-<<#parameters.include-branch-in-cache-key>>{{ .Branch }}-<</parameters.include-branch-in-cache-key>>{{ checksum "<< parameters.app-dir >>/poetry.lock" }}-<<#parameters.include-python-in-cache-key>>{{ checksum "/home/circleci/.pyenv/version" }}-<</parameters.include-python-in-cache-key>>
   - steps: <<parameters.pre-install-steps>>
   - when:
       condition:
@@ -136,7 +140,7 @@ steps:
               equal: [pipenv, << parameters.pkg-manager >>]
             steps:
               - save_cache:
-                  key: -venv-<<parameters.cache-version>>-<<#parameters.include-branch-in-cache-key>>{{ .Branch }}-<</parameters.include-branch-in-cache-key>>{{ checksum "<< parameters.app-dir >>/Pipfile.lock" }}
+                  key: -venv-<<parameters.cache-version>>-<<#parameters.include-branch-in-cache-key>>{{ .Branch }}-<</parameters.include-branch-in-cache-key>>{{ checksum "<< parameters.app-dir >>/Pipfile.lock" }}-<<#parameters.include-python-in-cache-key>>{{ checksum "/home/circleci/.pyenv/version" }}-<</parameters.include-python-in-cache-key>>
                   paths:
                     - /home/circleci/.local/share/virtualenvs
         - when:
@@ -144,7 +148,7 @@ steps:
               equal: [poetry, << parameters.pkg-manager >>]
             steps:
               - save_cache:
-                  key: -venv-<<parameters.cache-version>>-<<#parameters.include-branch-in-cache-key>>{{ .Branch }}-<</parameters.include-branch-in-cache-key>>{{ checksum "<< parameters.app-dir >>/poetry.lock" }}
+                  key: -venv-<<parameters.cache-version>>-<<#parameters.include-branch-in-cache-key>>{{ .Branch }}-<</parameters.include-branch-in-cache-key>>{{ checksum "<< parameters.app-dir >>/poetry.lock" }}-<<#parameters.include-python-in-cache-key>>{{ checksum "/home/circleci/.pyenv/version" }}-<</parameters.include-python-in-cache-key>>
                   paths:
                     - /home/circleci/.cache/pypoetry/virtualenvs
   - when:
@@ -155,7 +159,7 @@ steps:
               equal: [pipenv, << parameters.pkg-manager >>]
             steps:
               - save_cache:
-                  key: -pypi-<<parameters.cache-version>>-<<#parameters.include-branch-in-cache-key>>{{ .Branch }}-<</parameters.include-branch-in-cache-key>>{{ checksum "<< parameters.app-dir >>/Pipfile.lock" }}
+                  key: -pypi-<<parameters.cache-version>>-<<#parameters.include-branch-in-cache-key>>{{ .Branch }}-<</parameters.include-branch-in-cache-key>>{{ checksum "<< parameters.app-dir >>/Pipfile.lock" }}-<<#parameters.include-python-in-cache-key>>{{ checksum "/home/circleci/.pyenv/version" }}-<</parameters.include-python-in-cache-key>>
                   paths:
                     # pipenv caches a pypi mirror and the site-pacakges
                     - "/home/circleci/.cache/pip"
@@ -165,7 +169,7 @@ steps:
               equal: [poetry, << parameters.pkg-manager >>]
             steps:
               - save_cache:
-                  key: -pypi-<<parameters.cache-version>>-<<#parameters.include-branch-in-cache-key>>{{ .Branch }}-<</parameters.include-branch-in-cache-key>>{{ checksum "<< parameters.app-dir >>/poetry.lock" }}
+                  key: -pypi-<<parameters.cache-version>>-<<#parameters.include-branch-in-cache-key>>{{ .Branch }}-<</parameters.include-branch-in-cache-key>>{{ checksum "<< parameters.app-dir >>/poetry.lock" }}-<<#parameters.include-python-in-cache-key>>{{ checksum "/home/circleci/.pyenv/version" }}-<</parameters.include-python-in-cache-key>>
                   paths:
                     # poetry only maintains a pypi mirror
                     - /home/circleci/.cache/pip
@@ -176,7 +180,7 @@ steps:
                 - equal: [pip-dist, << parameters.pkg-manager >>]
             steps:
               - save_cache:
-                  key: -pypi-<<parameters.cache-version>>-<<#parameters.include-branch-in-cache-key>>{{ .Branch }}-<</parameters.include-branch-in-cache-key>>{{ checksum "<< parameters.app-dir >>/<<parameters.pip-dependency-file>>" }}
+                  key: -pypi-<<parameters.cache-version>>-<<#parameters.include-branch-in-cache-key>>{{ .Branch }}-<</parameters.include-branch-in-cache-key>>{{ checksum "<< parameters.app-dir >>/<<parameters.pip-dependency-file>>" }}-<<#parameters.include-python-in-cache-key>>{{ checksum "/home/circleci/.pyenv/version" }}-<</parameters.include-python-in-cache-key>>
                   paths:
                     # depending on how pip is used, store the pypi mirror, pyenv 'global' the site-packages, and user site-pacakges
                     - /home/circleci/.cache/pip

--- a/src/commands/install-packages.yml
+++ b/src/commands/install-packages.yml
@@ -49,7 +49,7 @@ parameters:
     type: boolean
     default: true
     description: >
-      If true, this cache bucket will checksum the pyenv python binary with the cache-key.
+      If true, this cache bucket will checksum the pyenv python version with the cache-key.
 
 steps:
   - when:

--- a/src/jobs/test.yml
+++ b/src/jobs/test.yml
@@ -57,7 +57,7 @@ parameters:
     type: boolean
     default: true
     description: >
-      If true, this cache bucket will checksum the pyenv python binary with the cache-key
+      If true, this cache bucket will checksum the pyenv python version with the cache-key
 
 executor:
   name: default

--- a/src/jobs/test.yml
+++ b/src/jobs/test.yml
@@ -53,6 +53,11 @@ parameters:
     default: true
     description: >
       If true, this cache bucket will only apply to jobs within the same branch.
+  include-python-in-cache-key:
+    type: boolean
+    default: true
+    description: >
+      If true, this cache bucket will checksum the pyenv python binary with the cache-key
 
 executor:
   name: default
@@ -70,6 +75,7 @@ steps:
       include-branch-in-cache-key: <<parameters.include-branch-in-cache-key>>
       args: <<parameters.args>>
       pip-dependency-file: <<parameters.pip-dependency-file>>
+      include-python-in-cache-key: <<parameters.include-python-in-cache-key>>
   - when:
       condition:
         equal: ["unittest", << parameters.test-tool >>]


### PR DESCRIPTION
Adds the currently set version of python to the cache key via checksum of `/home/circleci/.pyenv/version`. Since the cache paths already assume the use of pyenv, this makes the most sense.

I had an issue reproducing it on the install of requirements, but a bad cache restore still restores enough for pyenv to switch to the badly cached version - this shouldn't happen.

Fixes #51 