### PR TITLE
[semver:patch] Allow no requirements.txt

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,6 +134,11 @@ workflows:
           pkg-manager: pip
           app-dir: ~/project/sample_pip
       - python/test:
+          name: job-test-pip-no-reqs
+          pkg-manager: pip
+          pip-dependency-file: ""
+          app-dir: ~/project/sample_pip
+      - python/test:
           version: 3.8.2
           name: job-test-pip-dist
           pkg-manager: pip-dist

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,8 +27,21 @@ jobs:
           name: "Test"
           working_directory: ~/project/sample_pip
           command: |
-            ls -l
-            # pytest would be a dep in requirements.txt
+            pytest
+
+  pip-install-test-args:
+    executor: python/default
+    steps:
+      - checkout
+      - python/install-packages:
+          pkg-manager: pip
+          app-dir: ~/project/sample_pip
+          args: pytest
+          pip-dependency-file: ""
+      - run:
+          name: "Test"
+          working_directory: ~/project/sample_pip
+          command: |
             pytest
 
   dist-test:
@@ -115,6 +128,7 @@ workflows:
     when: << pipeline.parameters.run-integration-tests >>
     jobs:
       - pip-install-test
+      - pip-install-test-args
       - pipenv-test
       - poetry-test
       - dist-test
@@ -170,6 +184,7 @@ workflows:
           ssh-fingerprints: 1a:d8:ea:eb:7a:ae:0c:9d:eb:e9:37:0f:66:62:36:9b
           requires:
             - pip-install-test
+            - pip-install-test-args
             - pipenv-test
             - poetry-test
             - job-test-poetry

--- a/sample_pip/src/example.py
+++ b/sample_pip/src/example.py
@@ -1,0 +1,5 @@
+
+
+def add_func(x,y):
+    z = x+y
+    return z

--- a/sample_pip/tests/test_ex.py
+++ b/sample_pip/tests/test_ex.py
@@ -1,0 +1,11 @@
+from src import example
+
+import unittest
+
+class TestCase(unittest.TestCase):
+
+    def test_add1(self):
+        assert example.add_func(5,5) == 10
+
+    def test_add2(self):
+        assert example.add_func(5,10) == 15

--- a/src/commands/install-packages.yml
+++ b/src/commands/install-packages.yml
@@ -116,10 +116,13 @@ steps:
               poetry install << parameters.args >>
   - when:
       condition:
+        # if pip == pkgmanager and args != "" or pip-depencyfile != ""
         and:
           - equal: [pip, << parameters.pkg-manager >>]
-          - and:
-            - not: <<parameters.args>>
+          - or:
+            # true if no arguements
+            - <<parameters.args>>
+            # true if dep file
             - <<parameters.pip-dependency-file>>
       steps:
         - run:

--- a/src/commands/install-packages.yml
+++ b/src/commands/install-packages.yml
@@ -52,6 +52,7 @@ parameters:
       If true, this cache bucket will checksum the pyenv python version with the cache-key.
 
 steps:
+  - run: echo <<parameters.args>> && echo <<parameters.pip-dependency-file>>
   - when:
       condition: << parameters.pypi-cache >>
       steps:

--- a/src/commands/install-packages.yml
+++ b/src/commands/install-packages.yml
@@ -12,13 +12,14 @@ parameters:
   args:
     type: string
     default: ""
-    description: Arguments to pass to install command for pipenv and poetry. For pip, args are after `-r requirements.txt` as package index options.
+    description: Arguments to pass to install command for pipenv and poetry. For pip, arguments are after the command, `pip install -r requirements.txt <args>`.
   pip-dependency-file:
     type: string
     default: requirements.txt
     description: |
       Name of the requirements file that needs to be installed with pip. Prepended with `app-dir`. If using pipenv or poetry, this is ignored.
       If using `pip-dist`, use this to use the cache checksum against the `setup.py` if desired.
+      If `pip-dependency-file` is set to an empty string, no dependency file is used in the `pip install` command.
   app-dir:
     type: string
     default: "~/project"

--- a/src/commands/install-packages.yml
+++ b/src/commands/install-packages.yml
@@ -119,8 +119,9 @@ steps:
       condition:
         and:
           - equal: [pip, << parameters.pkg-manager >>]
-          - not: <<parameters.args>>
-          - not: <<parameters.pip-dependency-file>>
+          - and:
+            - not: <<parameters.args>>
+            - <<parameters.pip-dependency-file>>
       steps:
         - run:
             name: "Install dependencies with pip using project <<parameters.pip-dependency-file>>"

--- a/src/commands/install-packages.yml
+++ b/src/commands/install-packages.yml
@@ -116,13 +116,18 @@ steps:
               poetry install << parameters.args >>
   - when:
       condition:
-        equal: [pip, << parameters.pkg-manager >>]
+        and:
+          - equal: [pip, << parameters.pkg-manager >>]
+          - not:
+              equal: ["", <<parameters.args>>]
+          - not:
+              equal: ["", <<parameters.pip-dependency-file>>]
       steps:
         - run:
             name: "Install dependencies with pip using project <<parameters.pip-dependency-file>>"
             working_directory: <<parameters.app-dir>>
             command: |
-              pip install -r <<parameters.pip-dependency-file>> << parameters.args >>
+              pip install <<#parameters.pip-dependency-file>>-r <<parameters.pip-dependency-file>><</parameters.pip-dependency-file>> << parameters.args >>
   - when:
       condition:
         equal: [pip-dist, << parameters.pkg-manager >>]

--- a/src/commands/install-packages.yml
+++ b/src/commands/install-packages.yml
@@ -118,10 +118,8 @@ steps:
       condition:
         and:
           - equal: [pip, << parameters.pkg-manager >>]
-          - not:
-              equal: ["", <<parameters.args>>]
-          - not:
-              equal: ["", <<parameters.pip-dependency-file>>]
+          - not: <<parameters.args>>
+          - not: <<parameters.pip-dependency-file>>
       steps:
         - run:
             name: "Install dependencies with pip using project <<parameters.pip-dependency-file>>"

--- a/src/commands/install-packages.yml
+++ b/src/commands/install-packages.yml
@@ -52,7 +52,6 @@ parameters:
       If true, this cache bucket will checksum the pyenv python version with the cache-key.
 
 steps:
-  - run: echo <<parameters.args>> && echo <<parameters.pip-dependency-file>>
   - when:
       condition: << parameters.pypi-cache >>
       steps:


### PR DESCRIPTION
Some projects don't have requirements.txt, i.e. in the case of an orb using python scripts to run the test job. 

This change allows you to set `pip-dependency-file` to an empty string, this will remove the `-r requirements.txt` from the pip install command. If `args` are also blank, the entire `pip install` step is skipped

The example below would skip running the `pip install` step.
```
      - python/test:
          name: job-test-pip-no-reqs
          pkg-manager: pip
          pip-dependency-file: ""
          app-dir: ~/project/sample_pip
```

The example below would not use a requirements.txt, but would still install the `args`.
```
      - python/test:
          name: job-test-pip-no-reqs
          pkg-manager: pip
          args: pytest
          pip-dependency-file: ""
          app-dir: ~/project/sample_pip
```