### PR TITLE
Add `pipenv-venv-in-project` parameter to `install-packages` command

### DIFF
--- a/src/commands/install-packages.yml
+++ b/src/commands/install-packages.yml
@@ -60,6 +60,11 @@ parameters:
     default: true
     description: >
       If true, this cache bucket will checksum the pyenv python version with the cache-key.
+  pipenv-venv-in-project:
+    type: boolean
+    default: false
+    description: >
+      If true, pipenv is given as `pkg-manager` and `venv-cache` is enabled, the virtualenv is expected in the project directory instead of `/home/circleci/.local/share/virtualenvs`.
 
 steps:
   - when:
@@ -159,7 +164,7 @@ steps:
               - save_cache:
                   key: -venv-<<parameters.cache-version>>-<<#parameters.include-branch-in-cache-key>>{{ .Branch }}-<</parameters.include-branch-in-cache-key>>{{ checksum "<< parameters.app-dir >>/Pipfile.lock" }}-<<#parameters.include-python-in-cache-key>>{{ checksum "/home/circleci/.pyenv/version" }}-<</parameters.include-python-in-cache-key>>
                   paths:
-                    - /home/circleci/.local/share/virtualenvs
+                    - <<# parameters.pipenv-venv-in-project >><< parameters.app-dir >>/.venv<</ parameters.pipenv-venv-in-project >><<^ parameters.pipenv-venv-in-project >>/home/circleci/.local/share/virtualenvs<</ parameters.pipenv-venv-in-project >>
         - when:
             condition:
               equal: [poetry, << parameters.pkg-manager >>]


### PR DESCRIPTION
### Short description

Hi, I faced the problem that I couldn't make use of the `venv-cache` when I set the environment variable `PIPENV_VENV_IN_PROJECT` and opened issue #79. This PR aims to solve that problem.

### Proposed solution:

When `pipenv-venv-in-project` is set to `true`, the caching mechanism `venv-cache` is enabled and pipenv is set as `pkg-manager`, this will assume the environment variable `PIPENV_VENV_IN_PROJECT` which means that pipenv creates the virtual environment inside a directory called `.venv` inside the project directory instead of the default location `/home/circleci/.local/share/virtualenvs`.

### Alternative solution:
I could also implement this as string parameter for the venv location with default value `/home/circleci/.local/share/virtualenvs`


### Resolved issues
Fixes: #79

Thanks in advance for your feedback!
