### PR TITLE
[semver:minor] add parameter to pass arguments to test tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 src/orb.yml
+
+# dev tools
+.idea

--- a/src/jobs/test.yml
+++ b/src/jobs/test.yml
@@ -36,6 +36,10 @@ parameters:
     enum: ["pytest", "unittest"]
     default: "unittest"  # default since its not an external requirement
     description: The tool to run the tests with.
+  test-tool-args:
+    type: string
+    default: ""
+    description: Arguments to pass to test tool, i.e. discovery settings for unittest - 'discover -s tests_dir'.
   venv-cache:
     type: boolean
     default: true
@@ -88,7 +92,7 @@ steps:
             steps:
               - run:
                   name: Run tests with <<parameters.pkg-manager>> run
-                  command: <<parameters.pkg-manager>> run python -m unittest
+                  command: <<parameters.pkg-manager>> run python -m unittest << parameters.test-tool-args >>
         - when:
             condition:
               or:
@@ -102,7 +106,7 @@ steps:
                   # add the project to the path
                   command: |
                     export PYTHONPATH=$PWD:$PYTHONPATH
-                    python -m unittest
+                    python -m unittest << parameters.test-tool-args >>
   - when:
       condition:
         equal: ["pytest", << parameters.test-tool >>]
@@ -120,7 +124,7 @@ steps:
               - run:
                   name: Run tests with <<parameters.pkg-manager>> run
                   working_directory: <<parameters.app-dir>>
-                  command: <<parameters.pkg-manager>> run pytest --junit-xml=test-report/report.xml
+                  command: <<parameters.pkg-manager>> run pytest --junit-xml=test-report/report.xml << parameters.test-tool-args >>
         - when:
             condition:
               or:
@@ -130,6 +134,6 @@ steps:
               - run:
                   name: Run tests with global python env
                   working_directory: <<parameters.app-dir>>
-                  command: pytest --junit-xml=test-report/report.xml
+                  command: pytest --junit-xml=test-report/report.xml << parameters.test-tool-args >>
         - store_test_results:
             path: <<#parameters.app-dir>><<parameters.app-dir>>/<</parameters.app-dir>>test-report


### PR DESCRIPTION
## Description
- add `test-tool-args` parameter to end of test tool running commands
- added IntelliJ config dir into .gitignore

## Motivation
I usually put my test files into `test` directory, and manually run `python -m unittest discover -s test`.

I am happy with orb's `python/test` job as it covers all my needs out of the box ... except for this one. There is a workaround with `test_setup.py`-like file that is put into root dir and basically provides list of test files for test suite, and one can simply enumerate files in `test` dir or whatever. But why put another file into root folder? You can simply pass argument to `unittest`. 

Also this is unittest-specific workaround and there are other ways for other tools like `pytest`.

There is similar `args` [parameter](https://github.com/CircleCI-Public/python-orb/blob/0b14cd9764556eec54fe4442d57eab337a7c923c/src/commands/install-packages.yml#L142) that passes additional arguments to `pip install`. 
I made similar parameter `test-tool-args` that is being added to the end of running test tools line.