### PR TITLE
Do not fail cache key computation in case of no 'pip-dependency-file'

### DIFF
--- a/src/commands/install-packages.yml
+++ b/src/commands/install-packages.yml
@@ -87,7 +87,7 @@ steps:
             steps:
               - restore_cache:
                   keys:
-                    - -pypi-<<parameters.cache-version>>-<<#parameters.include-branch-in-cache-key>>{{ .Branch }}-<</parameters.include-branch-in-cache-key>>{{ checksum "<< parameters.app-dir >>/<<parameters.pip-dependency-file>>" }}-<<#parameters.include-python-in-cache-key>>{{ checksum "/home/circleci/.pyenv/version" }}-<</parameters.include-python-in-cache-key>>
+                    - -pypi-<<parameters.cache-version>>-<<#parameters.include-branch-in-cache-key>>{{ .Branch }}-<</parameters.include-branch-in-cache-key>><<#parameters.pip-dependency-file>>{{ checksum "<< parameters.app-dir >>/<<parameters.pip-dependency-file>>" }}-<</parameters.pip-dependency-file>><<#parameters.include-python-in-cache-key>>{{ checksum "/home/circleci/.pyenv/version" }}-<</parameters.include-python-in-cache-key>>
   - when:
       condition: << parameters.venv-cache >>
       steps:
@@ -197,7 +197,7 @@ steps:
                 - equal: [pip-dist, << parameters.pkg-manager >>]
             steps:
               - save_cache:
-                  key: -pypi-<<parameters.cache-version>>-<<#parameters.include-branch-in-cache-key>>{{ .Branch }}-<</parameters.include-branch-in-cache-key>>{{ checksum "<< parameters.app-dir >>/<<parameters.pip-dependency-file>>" }}-<<#parameters.include-python-in-cache-key>>{{ checksum "/home/circleci/.pyenv/version" }}-<</parameters.include-python-in-cache-key>>
+                  key: -pypi-<<parameters.cache-version>>-<<#parameters.include-branch-in-cache-key>>{{ .Branch }}-<</parameters.include-branch-in-cache-key>><<#parameters.pip-dependency-file>>{{ checksum "<< parameters.app-dir >>/<<parameters.pip-dependency-file>>" }}<</parameters.pip-dependency-file>>-<<#parameters.include-python-in-cache-key>>{{ checksum "/home/circleci/.pyenv/version" }}-<</parameters.include-python-in-cache-key>>
                   paths:
                     # depending on how pip is used, store the pypi mirror, pyenv 'global' the site-packages, and user site-pacakges
                     - /home/circleci/.cache/pip


### PR DESCRIPTION
It was not failing the build but failing the use of cache.

Before this patch: https://app.circleci.com/pipelines/github/CircleCI-Public/python-orb/339/workflows/fa79d98d-a100-4955-885a-47f70dfd5cb0/jobs/1434
![image](https://user-images.githubusercontent.com/175128/144710063-73a7711c-de9c-4428-8d54-6ee988c5fff4.png)
