### PR TITLE
fix(cache): wrong check for symbolic link

### DIFF
--- a/src/scripts/cache-save.sh
+++ b/src/scripts/cache-save.sh
@@ -63,7 +63,7 @@ fi
 
 LOCKFILE_PATH="${CACHE_DIR}/lockfile"
 
-if [ -f "${LOCKFILE_PATH}" ]; then
+if [ -L "${LOCKFILE_PATH}" ]; then
     unlink "${LOCKFILE_PATH}"
 fi
 

--- a/src/scripts/cache-save.sh
+++ b/src/scripts/cache-save.sh
@@ -63,9 +63,7 @@ fi
 
 LOCKFILE_PATH="${CACHE_DIR}/lockfile"
 
-if [ -L "${LOCKFILE_PATH}" ]; then
-    unlink "${LOCKFILE_PATH}"
-fi
+rm -vf "${LOCKFILE_PATH}"
 
 if [ -f "${LOCK_FILE}" ]; then
     ln "${LOCK_FILE}" "${LOCKFILE_PATH}"


### PR DESCRIPTION

Problem at  "Copy to cache directory"  step

```
ln: failed to create hard link '/tmp/cci_pycache/lockfile': File exists

Exited with code exit status 1
CircleCI received exit code 1
```

```
circleci@ID:~/project$ ls -lah /tmp/cci_pycache/lockfile
lrwxrwxrwx 1 circleci circleci 14 Feb  9 14:23 /tmp/cci_pycache/lockfile -> ./Pipfile.lock
circleci@ID:~/project$ if [ -f "/tmp/cci_pycache/lockfile" ]; then echo "do unlink"; fi
circleci@ID:~/project$ ls -lah /tmp/cci_pycache/lockfile
lrwxrwxrwx 1 circleci circleci 14 Feb  9 14:23 /tmp/cci_pycache/lockfile -> ./Pipfile.lock
circleci@ID:~/project$ if [ -L "/tmp/cci_pycache/lockfile" ]; then echo "do unlink"; fi
do unlink
```

issue: https://github.com/CircleCI-Public/python-orb/pull/83#issuecomment-1033777125