### PR TITLE
fix: Lockfile path not found [semver:patch]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,9 +35,9 @@ jobs:
 
   pip-install-local-dir:
     executor: python/default
+    working_directory: ~/project/sample_pip
     steps:
       - checkout
-      - run: cd sample_pip
       - python/install-packages:
           pkg-manager: pip
           cache-version: << pipeline.parameters.cache-version >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,9 +35,9 @@ jobs:
 
   pip-install-local-dir:
     executor: python/default
-    working_directory: ~/project/sample_pip
     steps:
       - checkout
+      - run: mv ./sample_pip/* .
       - python/install-packages:
           pkg-manager: pip
           cache-version: << pipeline.parameters.cache-version >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ jobs:
       - run: ls -la sample_pip
       - run: readlink -f "."
       - run: readlink -f "./sample_pip"
-      - run: readlink -f "./sample_pip/requirements.txt"
+      - run: readlink -f ./sample_pip/requirements.txt
       - run: readlink -f ~/project/sample_pip/requirements.txt
       - python/install-packages:
           pkg-manager: pip

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,19 @@ jobs:
           command: |
             pytest
 
+  pip-install-local-dir:
+    executor: python/default
+    working_directory: ~/project/sample_pip
+    steps:
+      - checkout
+      - python/install-packages:
+          pkg-manager: pip
+          cache-version: << pipeline.parameters.cache-version >>
+      - run:
+          name: "Test"
+          command: |
+            pytest
+
   pip-install-test-no-packages:
     executor: python/default
     steps:
@@ -151,6 +164,7 @@ workflows:
       - pipenv-test
       - poetry-test
       - dist-test
+      - pip-install-local-dir
       - python/test:
           name: job-test-poetry
           pkg-manager: poetry
@@ -268,6 +282,7 @@ workflows:
             - pip-install-test-args
             - pipenv-test
             - poetry-test
+            - pip-install-local-dir
             - job-test-poetry
             - job-test-pipenv
             - job-test-pip

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ parameters:
     default: "dev:alpha"
   cache-version:
     type: string
-    default: v20
+    default: v2
 
 jobs:
   pip-install-test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ jobs:
       - python/install-packages:
           pkg-manager: pip
           cache-version: << pipeline.parameters.cache-version >>
-          working_directory: ./sample_pip
+          app-dir: ./sample_pip
       - run:
           name: "Test"
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,6 +44,7 @@ jobs:
           app-dir: ./sample_pip
       - run:
           name: "Test"
+          working_directory: ~/project/sample_pip
           command: |
             pytest
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,12 +35,14 @@ jobs:
 
   pip-install-local-dir:
     executor: python/default
+    working_directory: ~/project/sample_pip
     steps:
       - checkout
-      - run: mv ./sample_pip/* .
       - python/install-packages:
           pkg-manager: pip
           cache-version: << pipeline.parameters.cache-version >>
+          pre-install-steps: 
+            run: pwd
       - run:
           name: "Test"
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,6 +37,7 @@ jobs:
     executor: python/default
     steps:
       - checkout
+      - run: ls -la
       - python/install-packages:
           pkg-manager: pip
           cache-version: << pipeline.parameters.cache-version >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
     executor: python/default
     steps:
       - checkout
-      - run: ls -la
+      - run: ls -la ./sample_pip
       - python/install-packages:
           pkg-manager: pip
           cache-version: << pipeline.parameters.cache-version >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,11 +38,10 @@ jobs:
     working_directory: ~/project/sample_pip
     steps:
       - checkout
+      - run: pwd
       - python/install-packages:
           pkg-manager: pip
           cache-version: << pipeline.parameters.cache-version >>
-          pre-install-steps: 
-            run: pwd
       - run:
           name: "Test"
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ parameters:
     default: "dev:alpha"
   cache-version:
     type: string
-    default: v3
+    default: v2
 
 jobs:
   pip-install-test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,9 +35,9 @@ jobs:
 
   pip-install-local-dir:
     executor: python/default
-    working_directory: ~/project/sample_pip
     steps:
       - checkout
+      - run: cd sample_pip
       - python/install-packages:
           pkg-manager: pip
           cache-version: << pipeline.parameters.cache-version >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,15 +33,14 @@ jobs:
           command: |
             pytest
 
-  pip-install-local-dir:
+  pip-install-rel-dir:
     executor: python/default
-    working_directory: ~/project/sample_pip
     steps:
       - checkout
-      - run: pwd
       - python/install-packages:
           pkg-manager: pip
           cache-version: << pipeline.parameters.cache-version >>
+          working_directory: ./sample_pip
       - run:
           name: "Test"
           command: |
@@ -165,7 +164,7 @@ workflows:
       - pipenv-test
       - poetry-test
       - dist-test
-      - pip-install-local-dir
+      - pip-install-rel-dir
       - python/test:
           name: job-test-poetry
           pkg-manager: poetry
@@ -283,7 +282,7 @@ workflows:
             - pip-install-test-args
             - pipenv-test
             - poetry-test
-            - pip-install-local-dir
+            - pip-install-rel-dir
             - job-test-poetry
             - job-test-pipenv
             - job-test-pip

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,11 +37,6 @@ jobs:
     executor: python/default
     steps:
       - checkout
-      - run: ls -la sample_pip
-      - run: readlink -f "."
-      - run: readlink -f "./sample_pip"
-      - run: readlink -f ./sample_pip/requirements.txt
-      - run: readlink -f ~/project/sample_pip/requirements.txt
       - python/install-packages:
           pkg-manager: pip
           cache-version: << pipeline.parameters.cache-version >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,11 +37,11 @@ jobs:
     executor: python/default
     steps:
       - checkout
-      - run: ls -la ./sample_pip
+      - run: ls -la sample_pip
       - python/install-packages:
           pkg-manager: pip
           cache-version: << pipeline.parameters.cache-version >>
-          app-dir: ./sample_pip
+          app-dir: sample_pip
       - run:
           name: "Test"
           working_directory: ~/project/sample_pip

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ jobs:
       - run: readlink -f "."
       - run: readlink -f "./sample_pip"
       - run: readlink -f "./sample_pip/requirements.txt"
-      - run: readlink -f "~/project/sample_pip/requirements.txt"
+      - run: readlink -f ~/project/sample_pip/requirements.txt
       - python/install-packages:
           pkg-manager: pip
           cache-version: << pipeline.parameters.cache-version >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ jobs:
       - run: readlink -f "."
       - run: readlink -f "./sample_pip"
       - run: readlink -f "./sample_pip/requirements.txt"
-      - run: readlink -f "~/sample_pip/requirements.txt"
+      - run: readlink -f "~/project/sample_pip/requirements.txt"
       - python/install-packages:
           pkg-manager: pip
           cache-version: << pipeline.parameters.cache-version >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ parameters:
     default: "dev:alpha"
   cache-version:
     type: string
-    default: v2
+    default: v3
 
 jobs:
   pip-install-test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,10 +38,14 @@ jobs:
     steps:
       - checkout
       - run: ls -la sample_pip
+      - run: readlink -f "."
+      - run: readlink -f "./sample_pip"
+      - run: readlink -f "./sample_pip/requirements.txt"
+      - run: readlink -f "~/sample_pip/requirements.txt"
       - python/install-packages:
           pkg-manager: pip
           cache-version: << pipeline.parameters.cache-version >>
-          app-dir: sample_pip
+          app-dir: "./sample_pip"
       - run:
           name: "Test"
           working_directory: ~/project/sample_pip

--- a/sample_poetry/poetry.lock
+++ b/sample_poetry/poetry.lock
@@ -205,7 +205,7 @@ description = "library with cross-python path, ini-parsing, io, code, log facili
 name = "py"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "1.9.0"
+version = "1.10.0"
 
 [[package]]
 category = "dev"

--- a/src/commands/install-packages.yml
+++ b/src/commands/install-packages.yml
@@ -102,7 +102,6 @@ steps:
             name: Link lockfile
             environment:
               PARAM_PKG_MNGR: << parameters.pkg-manager >>
-              PARAM_APP_DIR: << parameters.app-dir >>
               PARAM_DEPENDENCY_FILE: << parameters.pip-dependency-file >>
               PARAM_PYPI_CACHE: << parameters.pypi-cache >>
               PARAM_VENV_CACHE: << parameters.venv-cache >>
@@ -131,7 +130,6 @@ steps:
             no_output_timeout: << parameters.no_output_timeout >>
             environment:
               PARAM_PKG_MNGR: << parameters.pkg-manager >>
-              PARAM_APP_DIR: << parameters.app-dir >>
               PARAM_DEPENDENCY_FILE: << parameters.pip-dependency-file >>
               PARAM_PATH_ARGS: << parameters.path-args >>
               PARAM_ADDITIONAL_ARGS: << parameters.args >>
@@ -190,7 +188,6 @@ steps:
             working_directory: << parameters.app-dir >>
             environment:
               PARAM_PKG_MNGR: << parameters.pkg-manager >>
-              PARAM_APP_DIR: << parameters.app-dir >>
               PARAM_DEPENDENCY_FILE: << parameters.pip-dependency-file >>
               PARAM_VENV_CACHE: << parameters.venv-cache >>
               PARAM_PYPI_CACHE: << parameters.pypi-cache >>

--- a/src/scripts/auto-install-command.sh
+++ b/src/scripts/auto-install-command.sh
@@ -3,7 +3,7 @@ source "$AUTO_DETECT_ENV_SCRIPT"
 
 case ${DETECT_PKG_MNGR:-${PARAM_PKG_MNGR}} in
     pip)
-        PYTHON_INSTALL_ARGS="-r ${PARAM_APP_DIR}/${PARAM_DEPENDENCY_FILE:-requirements.txt}"
+        PYTHON_INSTALL_ARGS="-r ${PARAM_DEPENDENCY_FILE:-requirements.txt}"
     ;;
     pip-dist)
         PYTHON_INSTALL_ARGS="-e ${PARAM_PATH_ARGS}"

--- a/src/scripts/cache-link-lockfile.sh
+++ b/src/scripts/cache-link-lockfile.sh
@@ -25,10 +25,10 @@ if [ ! -f "${LOCKFILE_PATH}" ]; then
         echo "WARNING: Could not determine lockfile path for ${DETECT_PKG_MNGR:-PARAM_PKG_MNGR}"
     else
         pwd
-        FULL_LOCK_FILE=$(readlink -f -v "${LOCK_FILE}")
         echo ${FULL_LOCK_FILE}
 
-        if [ -f "${LOCK_FILE}" ]; then
+        if [ -e "${LOCK_FILE}" ]; then
+            FULL_LOCK_FILE=$(readlink -f -v "${LOCK_FILE}")
             
             echo "INFO: Linking ${FULL_LOCK_FILE} to ${LOCKFILE_PATH}"
             ln -s "${FULL_LOCK_FILE}" "${LOCKFILE_PATH}"

--- a/src/scripts/cache-link-lockfile.sh
+++ b/src/scripts/cache-link-lockfile.sh
@@ -22,9 +22,11 @@ if [ ! -f "${LOCKFILE_PATH}" ]; then
     if [ -z "${LOCK_FILE}" ]; then
         echo "WARNING: Could not determine lockfile path for ${DETECT_PKG_MNGR:-PARAM_PKG_MNGR}"
     else
+        FULL_LOCK_FILE=$(readlink -f -v "${LOCK_FILE}")
+
         if [ -f "${LOCK_FILE}" ]; then
-            echo "INFO: Linking ${LOCK_FILE} to ${LOCKFILE_PATH}"
-            ln -s "${LOCK_FILE}" "${LOCKFILE_PATH}"
+            echo "INFO: Linking ${FULL_LOCK_FILE} to ${LOCKFILE_PATH}"
+            ln -s "${FULL_LOCK_FILE}" "${LOCKFILE_PATH}"
         else
             echo "WARNING: Could not find lockfile at ${LOCK_FILE}"
         fi

--- a/src/scripts/cache-link-lockfile.sh
+++ b/src/scripts/cache-link-lockfile.sh
@@ -24,6 +24,8 @@ if [ ! -f "${LOCKFILE_PATH}" ]; then
     if [ -z "${LOCK_FILE}" ]; then
         echo "WARNING: Could not determine lockfile path for ${DETECT_PKG_MNGR:-PARAM_PKG_MNGR}"
     else
+        pwd
+
         if [ -f "${LOCK_FILE}" ]; then
             FULL_LOCK_FILE=$(readlink -f "${LOCK_FILE}")
             

--- a/src/scripts/cache-link-lockfile.sh
+++ b/src/scripts/cache-link-lockfile.sh
@@ -7,32 +7,24 @@ LOCKFILE_PATH="${CACHE_DIR}/lockfile"
 mkdir -p "${CACHE_DIR}"
 
 if [ ! -f "${LOCKFILE_PATH}" ]; then
-    eval PARAM_APP_DIR="${PARAM_APP_DIR}"
-    
     case ${DETECT_PKG_MNGR:-${PARAM_PKG_MNGR}} in
         pip | pip-dist)
-            LOCK_FILE="${PARAM_APP_DIR}/${PARAM_DEPENDENCY_FILE:-requirements.txt}"
+            LOCK_FILE="${PARAM_DEPENDENCY_FILE:-requirements.txt}"
         ;;
         pipenv)
-            LOCK_FILE="${PARAM_APP_DIR}/Pipfile.lock"
+            LOCK_FILE="Pipfile.lock"
         ;;
         poetry)
-            LOCK_FILE="${PARAM_APP_DIR}/poetry.lock"
+            LOCK_FILE="poetry.lock"
         ;;
     esac
     
     if [ -z "${LOCK_FILE}" ]; then
         echo "WARNING: Could not determine lockfile path for ${DETECT_PKG_MNGR:-PARAM_PKG_MNGR}"
     else
-        set -x
-        pwd
-        echo "${LOCK_FILE}"
-        FULL_LOCK_FILE=$(readlink -f -v "${LOCK_FILE}")
-        echo "${FULL_LOCK_FILE}"
-
-        if [ -f "${FULL_LOCK_FILE}" ]; then
-            echo "INFO: Linking ${FULL_LOCK_FILE} to ${LOCKFILE_PATH}"
-            ln -s "${FULL_LOCK_FILE}" "${LOCKFILE_PATH}"
+        if [ -f "${LOCK_FILE}" ]; then
+            echo "INFO: Linking ${LOCK_FILE} to ${LOCKFILE_PATH}"
+            ln -s "${LOCK_FILE}" "${LOCKFILE_PATH}"
         else
             echo "WARNING: Could not find lockfile at ${LOCK_FILE}"
         fi

--- a/src/scripts/cache-link-lockfile.sh
+++ b/src/scripts/cache-link-lockfile.sh
@@ -24,8 +24,9 @@ if [ ! -f "${LOCKFILE_PATH}" ]; then
     if [ -z "${LOCK_FILE}" ]; then
         echo "WARNING: Could not determine lockfile path for ${DETECT_PKG_MNGR:-PARAM_PKG_MNGR}"
     else
-        if [ -f "${LOCK_FILE}" ]; then
-            FULL_LOCK_FILE=$(readlink -f -v "${LOCK_FILE}")
+        FULL_LOCK_FILE=$(readlink -f -v "${LOCK_FILE}")
+
+        if [ -f "${FULL_LOCK_FILE}" ]; then
             
             echo "INFO: Linking ${FULL_LOCK_FILE} to ${LOCKFILE_PATH}"
             ln -s "${FULL_LOCK_FILE}" "${LOCKFILE_PATH}"

--- a/src/scripts/cache-link-lockfile.sh
+++ b/src/scripts/cache-link-lockfile.sh
@@ -25,10 +25,10 @@ if [ ! -f "${LOCKFILE_PATH}" ]; then
         echo "WARNING: Could not determine lockfile path for ${DETECT_PKG_MNGR:-PARAM_PKG_MNGR}"
     else
         pwd
+        FULL_LOCK_FILE=$(readlink -f -v "${LOCK_FILE}")
         echo ${FULL_LOCK_FILE}
 
-        if [ -e "${LOCK_FILE}" ]; then
-            FULL_LOCK_FILE=$(readlink -f -v "${LOCK_FILE}")
+        if [ -f "${FULL_LOCK_FILE}" ]; then
             
             echo "INFO: Linking ${FULL_LOCK_FILE} to ${LOCKFILE_PATH}"
             ln -s "${FULL_LOCK_FILE}" "${LOCKFILE_PATH}"

--- a/src/scripts/cache-link-lockfile.sh
+++ b/src/scripts/cache-link-lockfile.sh
@@ -25,9 +25,10 @@ if [ ! -f "${LOCKFILE_PATH}" ]; then
         echo "WARNING: Could not determine lockfile path for ${DETECT_PKG_MNGR:-PARAM_PKG_MNGR}"
     else
         pwd
+        FULL_LOCK_FILE=$(readlink -f -v "${LOCK_FILE}")
+        echo ${FULL_LOCK_FILE}
 
         if [ -f "${LOCK_FILE}" ]; then
-            FULL_LOCK_FILE=$(readlink -f "${LOCK_FILE}")
             
             echo "INFO: Linking ${FULL_LOCK_FILE} to ${LOCKFILE_PATH}"
             ln -s "${FULL_LOCK_FILE}" "${LOCKFILE_PATH}"

--- a/src/scripts/cache-link-lockfile.sh
+++ b/src/scripts/cache-link-lockfile.sh
@@ -27,7 +27,7 @@ if [ ! -f "${LOCKFILE_PATH}" ]; then
         pwd
         FULL_LOCK_FILE=$(readlink -f -v "${LOCK_FILE}")
         echo ${FULL_LOCK_FILE}
-        ls -la $(dirname ${FULL_LOCK_FILE})
+        ls -la .
 
         if [ -f "${FULL_LOCK_FILE}" ]; then
             

--- a/src/scripts/cache-link-lockfile.sh
+++ b/src/scripts/cache-link-lockfile.sh
@@ -24,10 +24,12 @@ if [ ! -f "${LOCKFILE_PATH}" ]; then
     if [ -z "${LOCK_FILE}" ]; then
         echo "WARNING: Could not determine lockfile path for ${DETECT_PKG_MNGR:-PARAM_PKG_MNGR}"
     else
+        set -x
+        echo "${LOCK_FILE}"
         FULL_LOCK_FILE=$(readlink -f -v "${LOCK_FILE}")
+        echo "${FULL_LOCK_FILE}"
 
         if [ -f "${FULL_LOCK_FILE}" ]; then
-            
             echo "INFO: Linking ${FULL_LOCK_FILE} to ${LOCKFILE_PATH}"
             ln -s "${FULL_LOCK_FILE}" "${LOCKFILE_PATH}"
         else

--- a/src/scripts/cache-link-lockfile.sh
+++ b/src/scripts/cache-link-lockfile.sh
@@ -25,8 +25,10 @@ if [ ! -f "${LOCKFILE_PATH}" ]; then
         echo "WARNING: Could not determine lockfile path for ${DETECT_PKG_MNGR:-PARAM_PKG_MNGR}"
     else
         if [ -f "${LOCK_FILE}" ]; then
-            echo "INFO: Linking ${LOCK_FILE} to ${LOCKFILE_PATH}"
-            ln -s "${LOCK_FILE}" "${LOCKFILE_PATH}"
+            FULL_LOCK_FILE=$(readlink -f "${LOCK_FILE}")
+            
+            echo "INFO: Linking ${FULL_LOCK_FILE} to ${LOCKFILE_PATH}"
+            ln -s "${FULL_LOCK_FILE}" "${LOCKFILE_PATH}"
         else
             echo "WARNING: Could not find lockfile at ${LOCK_FILE}"
         fi

--- a/src/scripts/cache-link-lockfile.sh
+++ b/src/scripts/cache-link-lockfile.sh
@@ -27,6 +27,7 @@ if [ ! -f "${LOCKFILE_PATH}" ]; then
         pwd
         FULL_LOCK_FILE=$(readlink -f -v "${LOCK_FILE}")
         echo ${FULL_LOCK_FILE}
+        ls -la $(dirname ${FULL_LOCK_FILE})
 
         if [ -f "${FULL_LOCK_FILE}" ]; then
             

--- a/src/scripts/cache-link-lockfile.sh
+++ b/src/scripts/cache-link-lockfile.sh
@@ -25,6 +25,7 @@ if [ ! -f "${LOCKFILE_PATH}" ]; then
         echo "WARNING: Could not determine lockfile path for ${DETECT_PKG_MNGR:-PARAM_PKG_MNGR}"
     else
         set -x
+        pwd
         echo "${LOCK_FILE}"
         FULL_LOCK_FILE=$(readlink -f -v "${LOCK_FILE}")
         echo "${FULL_LOCK_FILE}"

--- a/src/scripts/cache-link-lockfile.sh
+++ b/src/scripts/cache-link-lockfile.sh
@@ -24,12 +24,8 @@ if [ ! -f "${LOCKFILE_PATH}" ]; then
     if [ -z "${LOCK_FILE}" ]; then
         echo "WARNING: Could not determine lockfile path for ${DETECT_PKG_MNGR:-PARAM_PKG_MNGR}"
     else
-        pwd
-        FULL_LOCK_FILE=$(readlink -f -v "${LOCK_FILE}")
-        echo ${FULL_LOCK_FILE}
-        ls -la .
-
-        if [ -f "${FULL_LOCK_FILE}" ]; then
+        if [ -f "${LOCK_FILE}" ]; then
+            FULL_LOCK_FILE=$(readlink -f -v "${LOCK_FILE}")
             
             echo "INFO: Linking ${FULL_LOCK_FILE} to ${LOCKFILE_PATH}"
             ln -s "${FULL_LOCK_FILE}" "${LOCKFILE_PATH}"

--- a/src/scripts/cache-save.sh
+++ b/src/scripts/cache-save.sh
@@ -63,7 +63,7 @@ fi
 
 LOCKFILE_PATH="${CACHE_DIR}/lockfile"
 
-if [ -f "${LOCKFILE_PATH}" ]; then
+if [ -L "${LOCKFILE_PATH}" ]; then
     unlink "${LOCKFILE_PATH}"
 fi
 

--- a/src/scripts/cache-save.sh
+++ b/src/scripts/cache-save.sh
@@ -70,6 +70,8 @@ echo "${LOCK_FILE}"
 cd ~
 pwd
 ls -la ~
+cd "~/project/sample_pip/"
+readlink -f -v "./requirements.txt"
 readlink -f -v "${LOCK_FILE}"
 ls -la "$(dirname ${LOCK_FILE})"
 if [ -e "${LOCK_FILE}" ]; then

--- a/src/scripts/cache-save.sh
+++ b/src/scripts/cache-save.sh
@@ -10,7 +10,7 @@ case ${DETECT_PKG_MNGR:-${PARAM_PKG_MNGR}} in
     pipenv) # TODO: use PIPENV_PIPFILE
         LOCK_FILE="${PARAM_APP_DIR}/Pipfile.lock"
         PIPENV_VENV_PATH="${WORKON_HOME:-/home/circleci/.local/share/virtualenvs}"
-
+        
         if [ -z "${PIPENV_VENV_IN_PROJECT}" ]; then
             VENV_PATHS="[ \"${PIPENV_VENV_PATH}\" ]"
         else
@@ -40,7 +40,7 @@ link_paths() {
     fi
     
     mkdir "${1}"
-
+    
     for encoded in $(echo "${2}" | jq -r '.[] | @base64'); do
         decoded=$(echo "${encoded}" | base64 -d)
         
@@ -67,10 +67,9 @@ if [ -f "${LOCKFILE_PATH}" ]; then
     unlink "${LOCKFILE_PATH}"
 fi
 
-if [ -e "${LOCK_FILE}" ]; then  
-    echo "${LOCK_FILE}"
+if [ -e "${LOCK_FILE}" ]; then
     FULL_LOCK_FILE=$(readlink -f "${LOCK_FILE}")
-
+    
     echo "INFO: Linking ${FULL_LOCK_FILE} to ${LOCKFILE_PATH}"
     ln -s "${FULL_LOCK_FILE}" "${LOCKFILE_PATH}"
 fi

--- a/src/scripts/cache-save.sh
+++ b/src/scripts/cache-save.sh
@@ -67,7 +67,8 @@ if [ -f "${LOCKFILE_PATH}" ]; then
     unlink "${LOCKFILE_PATH}"
 fi
 
-if [ -e "${LOCK_FILE}" ]; then
+if [ -e "${LOCK_FILE}" ]; then  
+    echo "${LOCK_FILE}"
     FULL_LOCK_FILE=$(readlink -f "${LOCK_FILE}")
 
     echo "INFO: Linking ${FULL_LOCK_FILE} to ${LOCKFILE_PATH}"

--- a/src/scripts/cache-save.sh
+++ b/src/scripts/cache-save.sh
@@ -1,6 +1,5 @@
 # shellcheck source=detect-env.sh
 source "$AUTO_DETECT_ENV_SCRIPT"
-eval PARAM_APP_DIR="${PARAM_APP_DIR}"
 
 case ${DETECT_PKG_MNGR:-${PARAM_PKG_MNGR}} in
     pip | pip-dist)
@@ -14,7 +13,7 @@ case ${DETECT_PKG_MNGR:-${PARAM_PKG_MNGR}} in
         if [ -z "${PIPENV_VENV_IN_PROJECT}" ]; then
             VENV_PATHS="[ \"${PIPENV_VENV_PATH}\" ]"
         else
-            VENV_PATHS="[ \"${PARAM_APP_DIR}/.venvs\" ]"
+            VENV_PATHS="[ \"${CIRCLE_WORKING_DIRECTORY}/.venvs\" ]"
         fi
         
         CACHE_PATHS='[ "/home/circleci/.cache/pip", "/home/circleci/.cache/pipenv" ]'

--- a/src/scripts/cache-save.sh
+++ b/src/scripts/cache-save.sh
@@ -1,6 +1,5 @@
 # shellcheck source=detect-env.sh
 source "$AUTO_DETECT_ENV_SCRIPT"
-PARAM_APP_DIR="readlink -f ${PARAM_APP_DIR}"
 
 case ${DETECT_PKG_MNGR:-${PARAM_PKG_MNGR}} in
     pip | pip-dist)
@@ -68,5 +67,8 @@ if [ -f "${LOCKFILE_PATH}" ]; then
 fi
 
 if [ -f "${LOCK_FILE}" ]; then
-    ln "${LOCK_FILE}" "${LOCKFILE_PATH}"
+    FULL_LOCK_FILE=$(readlink -f "${LOCK_FILE}")
+    
+    echo "INFO: Linking ${FULL_LOCK_FILE} to ${LOCKFILE_PATH}"
+    ln -s "${FULL_LOCK_FILE}" "${LOCKFILE_PATH}"
 fi

--- a/src/scripts/cache-save.sh
+++ b/src/scripts/cache-save.sh
@@ -70,6 +70,8 @@ echo "${LOCK_FILE}"
 cd ~
 pwd
 ls -la ~
+cd "~/project/"
+ls -la
 ls -la "~/project/"
 cd "~/project/sample_pip/"
 readlink -f -v "./requirements.txt"

--- a/src/scripts/cache-save.sh
+++ b/src/scripts/cache-save.sh
@@ -67,9 +67,9 @@ if [ -f "${LOCKFILE_PATH}" ]; then
     unlink "${LOCKFILE_PATH}"
 fi
 
-readlink -f -v "${LOCK_FILE}"
 if [ -e "${LOCK_FILE}" ]; then
-    
+    FULL_LOCK_FILE=$(readlink -f "${LOCK_FILE}")
+
     echo "INFO: Linking ${FULL_LOCK_FILE} to ${LOCKFILE_PATH}"
     ln -s "${FULL_LOCK_FILE}" "${LOCKFILE_PATH}"
 fi

--- a/src/scripts/cache-save.sh
+++ b/src/scripts/cache-save.sh
@@ -4,11 +4,11 @@ eval PARAM_APP_DIR="${PARAM_APP_DIR}"
 
 case ${DETECT_PKG_MNGR:-${PARAM_PKG_MNGR}} in
     pip | pip-dist)
-        LOCK_FILE="${PARAM_APP_DIR}/${PARAM_DEPENDENCY_FILE:-requirements.txt}"
+        LOCK_FILE="${PARAM_DEPENDENCY_FILE:-requirements.txt}"
         CACHE_PATHS='[ "/home/circleci/.cache/pip", "/home/circleci/.pyenv/versions", "/home/circleci/.local/lib" ]'
     ;;
     pipenv) # TODO: use PIPENV_PIPFILE
-        LOCK_FILE="${PARAM_APP_DIR}/Pipfile.lock"
+        LOCK_FILE="Pipfile.lock"
         PIPENV_VENV_PATH="${WORKON_HOME:-/home/circleci/.local/share/virtualenvs}"
         
         if [ -z "${PIPENV_VENV_IN_PROJECT}" ]; then
@@ -20,7 +20,7 @@ case ${DETECT_PKG_MNGR:-${PARAM_PKG_MNGR}} in
         CACHE_PATHS='[ "/home/circleci/.cache/pip", "/home/circleci/.cache/pipenv" ]'
     ;;
     poetry)
-        LOCK_FILE="${PARAM_APP_DIR}/poetry.lock"
+        LOCK_FILE="poetry.lock"
         VENV_PATHS='[ "/home/circleci/.cache/pypoetry/virtualenvs" ]'
         CACHE_PATHS='[ "/home/circleci/.cache/pip" ]'
     ;;

--- a/src/scripts/cache-save.sh
+++ b/src/scripts/cache-save.sh
@@ -67,7 +67,7 @@ if [ -f "${LOCKFILE_PATH}" ]; then
 fi
 
 echo "${LOCK_FILE}"
-readlink -f "${LOCK_FILE}"
+readlink -f -v "${LOCK_FILE}"
 
 if [ -e "${LOCK_FILE}" ]; then
     

--- a/src/scripts/cache-save.sh
+++ b/src/scripts/cache-save.sh
@@ -1,5 +1,6 @@
 # shellcheck source=detect-env.sh
 source "$AUTO_DETECT_ENV_SCRIPT"
+eval PARAM_APP_DIR="${PARAM_APP_DIR}"
 
 case ${DETECT_PKG_MNGR:-${PARAM_PKG_MNGR}} in
     pip | pip-dist)
@@ -66,17 +67,7 @@ if [ -f "${LOCKFILE_PATH}" ]; then
     unlink "${LOCKFILE_PATH}"
 fi
 
-echo "${LOCK_FILE}"
-cd ~
-pwd
-ls -la ~
-cd "~/project"
-ls -la
-ls -la "~/project"
-cd "~/project/sample_pip/"
-readlink -f -v "./requirements.txt"
 readlink -f -v "${LOCK_FILE}"
-ls -la "$(dirname ${LOCK_FILE})"
 if [ -e "${LOCK_FILE}" ]; then
     
     echo "INFO: Linking ${FULL_LOCK_FILE} to ${LOCKFILE_PATH}"

--- a/src/scripts/cache-save.sh
+++ b/src/scripts/cache-save.sh
@@ -69,7 +69,9 @@ fi
 echo "${LOCK_FILE}"
 pwd
 ls -la "$(dirname ${LOCK_FILE})"
+ls -la ~
 readlink -f -v "${LOCK_FILE}"
+cd ~
 
 if [ -e "${LOCK_FILE}" ]; then
     

--- a/src/scripts/cache-save.sh
+++ b/src/scripts/cache-save.sh
@@ -70,9 +70,9 @@ echo "${LOCK_FILE}"
 cd ~
 pwd
 ls -la ~
-cd "~/project/"
+cd "~/project"
 ls -la
-ls -la "~/project/"
+ls -la "~/project"
 cd "~/project/sample_pip/"
 readlink -f -v "./requirements.txt"
 readlink -f -v "${LOCK_FILE}"

--- a/src/scripts/cache-save.sh
+++ b/src/scripts/cache-save.sh
@@ -67,6 +67,7 @@ if [ -f "${LOCKFILE_PATH}" ]; then
 fi
 
 echo "${LOCK_FILE}"
+ls -la "$(dirname ${LOCK_FILE})"
 readlink -f -v "${LOCK_FILE}"
 
 if [ -e "${LOCK_FILE}" ]; then

--- a/src/scripts/cache-save.sh
+++ b/src/scripts/cache-save.sh
@@ -67,6 +67,7 @@ if [ -f "${LOCKFILE_PATH}" ]; then
 fi
 
 echo "${LOCK_FILE}"
+pwd
 ls -la "$(dirname ${LOCK_FILE})"
 readlink -f -v "${LOCK_FILE}"
 

--- a/src/scripts/cache-save.sh
+++ b/src/scripts/cache-save.sh
@@ -1,6 +1,6 @@
 # shellcheck source=detect-env.sh
 source "$AUTO_DETECT_ENV_SCRIPT"
-eval PARAM_APP_DIR="${PARAM_APP_DIR}"
+PARAM_APP_DIR="readlink -f ${PARAM_APP_DIR}"
 
 case ${DETECT_PKG_MNGR:-${PARAM_PKG_MNGR}} in
     pip | pip-dist)

--- a/src/scripts/cache-save.sh
+++ b/src/scripts/cache-save.sh
@@ -67,12 +67,11 @@ if [ -f "${LOCKFILE_PATH}" ]; then
 fi
 
 echo "${LOCK_FILE}"
+cd ~
 pwd
-ls -la "$(dirname ${LOCK_FILE})"
 ls -la ~
 readlink -f -v "${LOCK_FILE}"
-cd ~
-
+ls -la "$(dirname ${LOCK_FILE})"
 if [ -e "${LOCK_FILE}" ]; then
     
     echo "INFO: Linking ${FULL_LOCK_FILE} to ${LOCKFILE_PATH}"

--- a/src/scripts/cache-save.sh
+++ b/src/scripts/cache-save.sh
@@ -66,7 +66,9 @@ if [ -f "${LOCKFILE_PATH}" ]; then
     unlink "${LOCKFILE_PATH}"
 fi
 
-if [ -f "${LOCK_FILE}" ]; then
+echo "${LOCK_FILE} $(readlink -f ${LOCK_FILE})"
+
+if [ -e "${LOCK_FILE}" ]; then
     FULL_LOCK_FILE=$(readlink -f "${LOCK_FILE}")
     
     echo "INFO: Linking ${FULL_LOCK_FILE} to ${LOCKFILE_PATH}"

--- a/src/scripts/cache-save.sh
+++ b/src/scripts/cache-save.sh
@@ -66,10 +66,10 @@ if [ -f "${LOCKFILE_PATH}" ]; then
     unlink "${LOCKFILE_PATH}"
 fi
 
-echo "${LOCK_FILE} $(readlink -f ${LOCK_FILE})"
+echo "${LOCK_FILE}"
+readlink -f "${LOCK_FILE}"
 
 if [ -e "${LOCK_FILE}" ]; then
-    FULL_LOCK_FILE=$(readlink -f "${LOCK_FILE}")
     
     echo "INFO: Linking ${FULL_LOCK_FILE} to ${LOCKFILE_PATH}"
     ln -s "${FULL_LOCK_FILE}" "${LOCKFILE_PATH}"

--- a/src/scripts/cache-save.sh
+++ b/src/scripts/cache-save.sh
@@ -70,6 +70,7 @@ echo "${LOCK_FILE}"
 cd ~
 pwd
 ls -la ~
+ls -la "~/project/"
 cd "~/project/sample_pip/"
 readlink -f -v "./requirements.txt"
 readlink -f -v "${LOCK_FILE}"


### PR DESCRIPTION
When providing the full cache path, everything was working file. However, using relative pathing was causing issues. This turned out to be a mixture of not using `readlink` to get the absolute path of the lockfile, also using the `app-dir` as the path caused a bug doubling up the relative path. 