### PR TITLE
Update install-packages.yml

### DIFF
--- a/src/commands/install-packages.yml
+++ b/src/commands/install-packages.yml
@@ -92,7 +92,7 @@ steps:
             working_directory: << parameters.app-dir >>
         - run:
             name: Save python version
-            command: python --version | cut -d' ' -f2 > /tmp/python-version
+            command: python --version | cut -d ' ' -f2 > /tmp/python-version
         - restore_cache:
             keys:
               - <<parameters.cache-version>>-cci_pycache-<<#parameters.include-branch-in-cache-key>>{{ .Branch }}-<</parameters.include-branch-in-cache-key>>{{ checksum "/tmp/cci_pycache/lockfile" }}-<<#parameters.include-python-in-cache-key>>{{ checksum "/tmp/python-version" }}-<</parameters.include-python-in-cache-key>>

--- a/src/commands/install-packages.yml
+++ b/src/commands/install-packages.yml
@@ -90,9 +90,12 @@ steps:
               PARAM_VENV_PATH: << parameters.venv-path >>
             command: <<include(scripts/cache-link-lockfile.sh)>>
             working_directory: << parameters.app-dir >>
+        - run:
+            name: Save python version
+            command: python --version | cut -d' ' -f2 > /tmp/python-version
         - restore_cache:
             keys:
-              - <<parameters.cache-version>>-cci_pycache-<<#parameters.include-branch-in-cache-key>>{{ .Branch }}-<</parameters.include-branch-in-cache-key>>{{ checksum "/tmp/cci_pycache/lockfile" }}-<<#parameters.include-python-in-cache-key>>{{ checksum "/home/circleci/.pyenv/version" }}-<</parameters.include-python-in-cache-key>>
+              - <<parameters.cache-version>>-cci_pycache-<<#parameters.include-branch-in-cache-key>>{{ .Branch }}-<</parameters.include-branch-in-cache-key>>{{ checksum "/tmp/cci_pycache/lockfile" }}-<<#parameters.include-python-in-cache-key>>{{ checksum "/tmp/python-version" }}-<</parameters.include-python-in-cache-key>>
         - run:
             name: Move restored cache
             working_directory: << parameters.app-dir >>


### PR DESCRIPTION
at the moment, this orb only works with the `cimg/python` images because it relies on `/home/circleci/.pyenv/version` file to exist (at least in the `install-packags` command)

this change saves the python version in a temp file instead, giving the orb more flexibility 