### PR TITLE
Use python -m build for PEP517 Compatibility

### DIFF
--- a/src/commands/dist.yml
+++ b/src/commands/dist.yml
@@ -1,18 +1,42 @@
-description: "Build a distribution package using distutils and setup.py"
+description: "Build a distribution package using PEP517"
 
 parameters:
   app-dir:
     type: string
     default: "."
     description: Path to the directory containing your python project. Not needed if 'setup.py' lives in root project dir
+  sdist-only:
+    type: boolean
+    default: false
+    description: Only build a source distribution. (Default behavior builds both sdist and wheel.)
+  wheel-only:
+    type: boolean
+    default: false
+    description: Only build a wheel, directly from the source. (Default behavior builds an sdist and a wheel from the sdist.)
+  out-dir:
+    type: string
+    default: "./dist"
+    description: Path where to write the output files
+  no-isolation:
+    type: boolean
+    default: false
+    description: Do not isolation the build in a virtual environment.
+  skip-dependency-check:
+    type: boolean
+    default: false
+    description: Do not check that build dependencies are installed.
+
 steps:
   - run:
-      name: Install wheel
-      command: pip install wheel
+      name: Install pypa build
+      command: pip install build
   - run:
       working_directory: << parameters.app-dir >>
       name: "Build distribution package"
-      command: |
-        python setup.py sdist
-        python setup.py bdist_wheel
-        ls -l dist
+      command: << include(scripts/pypa-build.sh) >>
+      environment:
+        PARAM_NO_ISOLATION: << parameters.no-isolation >>
+        PARAM_OUTDIR: << parameters.out-dir >>
+        PARAM_SDIST: << parameters.sdist-only >>
+        PARAM_SKIP_DEPENDENCY_CHECK: << parameters.skip-dependency-check >>
+        PARAM_WHEEL: << parameters.wheel-only >>

--- a/src/commands/dist.yml
+++ b/src/commands/dist.yml
@@ -20,7 +20,7 @@ parameters:
   no-isolation:
     type: boolean
     default: false
-    description: Do not isolation the build in a virtual environment.
+    description: Do not isolate the build in a virtual environment.
   skip-dependency-check:
     type: boolean
     default: false

--- a/src/scripts/pypa-build.sh
+++ b/src/scripts/pypa-build.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+main() {
+  local -a build_args
+  build_args=(
+    --outdir "$PARAM_OUTDIR"
+  )
+  [[ $PARAM_SDIST ]] && build_args+=( --sdist )
+  [[ $PARAM_WHEEL ]] && build_args+=( --wheel )
+  [[ $PARAM_SKIP_DEPENDENCY_CHECK ]] && build_args+=( --skip-dependency-check )
+  [[ $PARAM_NO_ISOLATION ]] && build_args+=( --no-isolation )
+  python -m build "${build_args[@]}" .
+  ls -l "$PARAM_OUTDIR"
+}
+
+main "$@"


### PR DESCRIPTION
**SEMVER Update Type:**

- [x] Major
- [ ] Minor
- [ ] Patch

## Description:

- Replace python -m wheel with python -m build.
- Fully support most of python -m build's parameters.


## Motivation:

[build](https://pypa-build.readthedocs.io/en/latest/) is a simple, correct [PEP 517](https://peps.python.org/pep-0517/) build frontend. Projects that support PEP 517, but not setuptools, will still build.


## Checklist:

<!--
	Thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions.
- [ ] Usage Example version numbers have been updated.
- [ ] Changelog has been updated.
