### PR TITLE
(CVL-599) Update detect env scripts to account for setuptools

### DIFF
--- a/src/scripts/detect-env.sh
+++ b/src/scripts/detect-env.sh
@@ -5,12 +5,16 @@ if [ "${PARAM_PKG_MNGR}" = "auto" ]; then
         else
             export DETECT_PKG_MNGR="pip"
         fi
-        elif [ -f "Pipfile" ]; then
+    elif [ -f "Pipfile" ]; then
         export DETECT_PKG_MNGR="pipenv"
         export PYTHON_ENV_TOOL="pipenv"
-        elif [ -f "pyproject.toml" ]; then
-        export DETECT_PKG_MNGR="poetry"
-        export PYTHON_ENV_TOOL="poetry"
+    elif [ -f "pyproject.toml" ]; then
+        if grep -q "setuptools" pyproject.toml; then
+            export DETECT_PKG_MNGR="pip-dist"
+        else
+            export DETECT_PKG_MNGR="poetry"
+            export PYTHON_ENV_TOOL="poetry"
+        fi 
     fi
     
     echo "INFO: Detected Package Manager ${DETECT_PKG_MNGR}"

--- a/src/scripts/export-detect-env.sh
+++ b/src/scripts/export-detect-env.sh
@@ -6,13 +6,16 @@ echo 'if [ "${PARAM_PKG_MNGR}" = "auto" ]; then
       else
           export DETECT_PKG_MNGR="pip"
       fi
-      elif [ -f "Pipfile" ]; then
+  elif [ -f "Pipfile" ]; then
       export DETECT_PKG_MNGR="pipenv"
       export PYTHON_ENV_TOOL="pipenv"
-      elif [ -f "pyproject.toml" ]; then
-      export DETECT_PKG_MNGR="poetry"
-      export PYTHON_ENV_TOOL="poetry"
-  fi
+  elif [ -f "pyproject.toml" ]; then
+      if grep -q "setuptools" pyproject.toml; then
+            export DETECT_PKG_MNGR="pip-dist"
+      else
+            export DETECT_PKG_MNGR="poetry"
+            export PYTHON_ENV_TOOL="poetry"
+      fi 
   echo "INFO: Detected Package Manager ${DETECT_PKG_MNGR}"
 fi' > /tmp/detect-env.sh
 chmod +x /tmp/detect-env.sh


### PR DESCRIPTION
We cannot assume that the existence of a pyproject.toml file indicates the package manager is poetry

Update detect logic to check for `setuptools` within the toml file and return the appropriate package manager.