### PR TITLE
Add no_output_timeout to install dependencies steps

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -13,8 +13,7 @@ parameters:
 executors:
   macos:
     macos:
-      xcode: 14.0.0
-    resource_class: medium
+      xcode: 16.1
 
 jobs:
   pip-install-test:

--- a/sample_pipenv/Pipfile.lock
+++ b/sample_pipenv/Pipfile.lock
@@ -14,62 +14,54 @@
         ]
     },
     "default": {
-        "attrs": {
+        "exceptiongroup": {
             "hashes": [
-                "sha256:2d27e3784d7a565d36ab851fe94887c5eccd6a463168875832a1be79c82828b4",
-                "sha256:626ba8234211db98e869df76230a137c4c40a12d72445c45d5f5b716f076e2fd"
+                "sha256:3111b9d131c238bec2f8f516e123e14ba243563fb135d3fe885990585aa7795b",
+                "sha256:47c2edf7c6738fafb49fd34290706d1a1a2f4d1c6df275526b62cbb4aa5393cc"
             ],
-            "version": "==21.4.0"
+            "markers": "python_version < '3.11'",
+            "version": "==1.2.2"
         },
         "iniconfig": {
             "hashes": [
-                "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3",
-                "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"
+                "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3",
+                "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374"
             ],
-            "version": "==1.1.1"
+            "markers": "python_version >= '3.7'",
+            "version": "==2.0.0"
         },
         "packaging": {
             "hashes": [
-                "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb",
-                "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"
+                "sha256:026ed72c8ed3fcce5bf8950572258698927fd1dbda10a5e981cdf0ac37f4f002",
+                "sha256:5b8f2217dbdbd2f7f384c41c628544e6d52f2d0f53c6d0c3ea61aa5d1d7ff124"
             ],
-            "version": "==21.3"
+            "markers": "python_version >= '3.8'",
+            "version": "==24.1"
         },
         "pluggy": {
             "hashes": [
-                "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159",
-                "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"
+                "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1",
+                "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669"
             ],
-            "version": "==1.0.0"
-        },
-        "py": {
-            "hashes": [
-                "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719",
-                "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"
-            ],
-            "version": "==1.11.0"
-        },
-        "pyparsing": {
-            "hashes": [
-                "sha256:18ee9022775d270c55187733956460083db60b37d0d0fb357445f3094eed3eea",
-                "sha256:a6c06a88f252e6c322f65faf8f418b16213b51bdfaece0524c1c1bc30c63c484"
-            ],
-            "version": "==3.0.7"
+            "markers": "python_version >= '3.8'",
+            "version": "==1.5.0"
         },
         "pytest": {
             "hashes": [
-                "sha256:131b36680866a76e6781d13f101efb86cf674ebb9762eb70d3082b6f29889e89",
-                "sha256:7310f8d27bc79ced999e760ca304d69f6ba6c6649c0b60fb0e04a4a77cacc134"
+                "sha256:70b98107bd648308a7952b06e6ca9a50bc660be218d53c257cc1fc94fda10181",
+                "sha256:a6853c7375b2663155079443d2e45de913a911a11d669df02a50814944db57b2"
             ],
             "index": "pypi",
-            "version": "==6.2.5"
+            "markers": "python_version >= '3.8'",
+            "version": "==8.3.3"
         },
-        "toml": {
+        "tomli": {
             "hashes": [
-                "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
-                "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
+                "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
+                "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"
             ],
-            "version": "==0.10.2"
+            "markers": "python_version < '3.11'",
+            "version": "==2.0.1"
         }
     },
     "develop": {}

--- a/src/commands/install-packages.yml
+++ b/src/commands/install-packages.yml
@@ -128,6 +128,7 @@ steps:
       steps:
         - run:
             name: "Install dependencies with pipenv using project Pipfile or inline packages"
+            no_output_timeout: << parameters.no_output_timeout >>
             working_directory: << parameters.app-dir >>
             command: |
               pipenv install << parameters.args >>
@@ -137,6 +138,7 @@ steps:
       steps:
         - run:
             name: "Install dependencies with poetry using project pyproject.toml"
+            no_output_timeout: << parameters.no_output_timeout >>
             working_directory: << parameters.app-dir >>
             command: |
               poetry install --no-ansi << parameters.args >>
@@ -153,6 +155,7 @@ steps:
       steps:
         - run:
             name: "Install dependencies with pip using project <<parameters.pip-dependency-file>>"
+            no_output_timeout: << parameters.no_output_timeout >>
             working_directory: <<parameters.app-dir>>
             command: |
               pip install <<#parameters.pip-dependency-file>>-r <<parameters.pip-dependency-file>><</parameters.pip-dependency-file>> << parameters.args >>
@@ -162,6 +165,7 @@ steps:
       steps:
         - run:
             name: "Install dependencies with pip using project setup.py"
+            no_output_timeout: << parameters.no_output_timeout >>
             working_directory: <<parameters.app-dir>>
             command: |
               pip install -e << parameters.path-args >> << parameters.args >>


### PR DESCRIPTION
Dependencies can take a long time to run without any output. A workaround is to add a "verbose" argument to the package manager args. But in cases where we don't want the output users would be able to use the `no_output_timeout` on the install step, not just the pre-install step.