### PR TITLE
Feat: remove version and add executor

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -244,7 +244,9 @@ workflows:
           app-dir: ~/project/sample_pip
       - python/test:
           filters: *filters
-          version: 3.8.2
+          executor:
+            name: python/default
+            tag: 3.8.2
           name: job-test-pip-dist
           pkg-manager: pip-dist
           include-branch-in-cache-key: false
@@ -262,7 +264,9 @@ workflows:
                 command: python --version
       - python/test:
           filters: *filters
-          version: 3.11.4
+          executor:
+            name: python/default
+            tag: 3.11.4
           name: job-test-pip-dist-pyproject
           pkg-manager: pip-dist
           include-branch-in-cache-key: false

--- a/src/examples/using-test-job.yml
+++ b/src/examples/using-test-job.yml
@@ -5,7 +5,7 @@ description: |
 usage:
   version: 2.1
   orbs:
-    python: circleci/python@1.0.0
+    python: circleci/python@3.0.0
   workflows:
     main:
       jobs:

--- a/src/examples/work-with-pip.yml
+++ b/src/examples/work-with-pip.yml
@@ -3,7 +3,7 @@ description: |
 usage:
   version: 2.1
   orbs:
-    python: circleci/python@1.1.0
+    python: circleci/python@3.0.0
   workflows:
     main:
       jobs:

--- a/src/examples/work-with-pipenv.yml
+++ b/src/examples/work-with-pipenv.yml
@@ -3,7 +3,7 @@ description: |
 usage:
   version: 2.1
   orbs:
-    python: circleci/python@1.0.0
+    python: circleci/python@3.0.0
   workflows:
     main:
       jobs:

--- a/src/examples/work-with-poetry.yml
+++ b/src/examples/work-with-poetry.yml
@@ -3,7 +3,7 @@ description: |
 usage:
   version: 2.1
   orbs:
-    python: circleci/python@1.0.0
+    python: circleci/python@3.0.0
   workflows:
     main:
       jobs:

--- a/src/jobs/test.yml
+++ b/src/jobs/test.yml
@@ -4,12 +4,11 @@ description: |
   Otherwise, use the built in unittest module as the test-tool.
 
 parameters:
-  version:
-    type: string
-    default: "3.8"
+  executor:
+    type: executor
+    default: default
     description: |
-      A full version tag must be specified. Example: "3.8"
-      For a full list of releases, see the following: https://hub.docker.com/r/cimg/python
+      The name of executor to use.
   pkg-manager:
     type: enum
     enum: [auto, pip, pipenv, poetry, pip-dist]
@@ -86,9 +85,7 @@ parameters:
     description: >
       Steps needed between restoring the cache and the install step.
 
-executor:
-  name: default
-  tag: << parameters.version >>
+executor: <<parameters.executor>>
 
 steps:
   - checkout


### PR DESCRIPTION
Resolves: #107 

I'm adding a parameter executor to the test job, this way it can be used in a more custom way when required. This changes removes the version parameter as they are mutually exclusive. The default executor will keep the same, but if someone is using a different version, it would need to be updated.
This is a breaking change and must be a major release.