### PR TITLE
Update cache version for tests

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -8,7 +8,7 @@ filters: &filters
 parameters:
   cache-version:
     type: string
-    default: v4
+    default: v5
 
 executors:
   macos:


### PR DESCRIPTION
I'm restarting the cache version of the tests as it is broken with the version changes.