### PR TITLE
chore: use correct orbs doc link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Example use as well as a list of available executors, commands, and jobs are ava
 ## Resources
 
 [CircleCI Orb Registry Page][reg-page] - The official registry page of this orb for all versions, executors, commands, and jobs described.
-[CircleCI Orb Docs](orb-docs) - Docs for using and creating CircleCI Orbs.
+[CircleCI Orb Docs][orb-docs] - Docs for using and creating CircleCI Orbs.
 
 ## Contributing
 


### PR DESCRIPTION
Hi, I just stumbled across this, the link [CircleCI Orb Docs](https://circleci.com/docs/2.0/orb-intro/#section=configuration) gave me page not found.